### PR TITLE
Daisyworld: remove outdated link

### DIFF
--- a/Sample Models/Biology/Daisyworld.nlogo
+++ b/Sample Models/Biology/Daisyworld.nlogo
@@ -530,8 +530,6 @@ An alternate Daisyworld model is listed on the [User Community Models](http://cc
 The Daisyworld model was first proposed and implemented by Lovelock and Andrew Watson. The original Gaia hypothesis is due to Lovelock.
 
 Watson, A.J., and J.E. Lovelock, 1983, "Biological homeostasis of the global environment: the parable of Daisyworld", Tellus 35B, 286-289. (The original paper by Watson and Lovelock introducing the Daisyworld model.)
-
-http://www.carleton.edu/departments/geol/DaveSTELLA/Daisyworld/daisyworld_model.htm
 @#$#@#$#@
 default
 true

--- a/Sample Models/Biology/Daisyworld.nlogo
+++ b/Sample Models/Biology/Daisyworld.nlogo
@@ -530,6 +530,8 @@ An alternate Daisyworld model is listed on the [User Community Models](http://cc
 The Daisyworld model was first proposed and implemented by Lovelock and Andrew Watson. The original Gaia hypothesis is due to Lovelock.
 
 Watson, A.J., and J.E. Lovelock, 1983, "Biological homeostasis of the global environment: the parable of Daisyworld", Tellus 35B, 286-289. (The original paper by Watson and Lovelock introducing the Daisyworld model.)
+
+Wikipedia also has a high-level description of the Daisyworld model: https://en.wikipedia.org/wiki/Daisyworld.
 @#$#@#$#@
 default
 true


### PR DESCRIPTION
I didn't find a replacement link, but I didn't search for one extensively either. The current references seem good enough anyway.

Closes https://github.com/NetLogo/NetLogo/issues/700.


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/netlogo/models/16)
<!-- Reviewable:end -->
