### PR TITLE
Ensure relevance of BehaviorSpace experiments in the library

### DIFF
--- a/IABM Textbook/chapter 4/Wolf Sheep Simple 5.nlogo
+++ b/IABM Textbook/chapter 4/Wolf Sheep Simple 5.nlogo
@@ -745,7 +745,7 @@ NetLogo 5.2.0
 @#$#@#$#@
 @#$#@#$#@
 <experiments>
-  <experiment name="experiment" repetitions="10" runMetricsEveryStep="false">
+  <experiment name="Wolf Sheep Simple model analysis" repetitions="10" runMetricsEveryStep="false">
     <setup>setup</setup>
     <go>go</go>
     <timeLimit steps="1000"/>

--- a/Sample Models/Chemistry & Physics/Lennard-Jones.nlogo
+++ b/Sample Models/Chemistry & Physics/Lennard-Jones.nlogo
@@ -789,25 +789,6 @@ NetLogo 5.2.0
 @#$#@#$#@
 @#$#@#$#@
 @#$#@#$#@
-<experiments>
-  <experiment name="experiment1" repetitions="1" runMetricsEveryStep="false">
-    <go>go</go>
-    <final>file-close-all</final>
-    <timeLimit steps="1000000"/>
-    <enumeratedValueSet variable="N">
-      <value value="100"/>
-    </enumeratedValueSet>
-    <enumeratedValueSet variable="Initial-Config">
-      <value value="&quot;random&quot;"/>
-    </enumeratedValueSet>
-    <enumeratedValueSet variable="Rho">
-      <value value="0.25"/>
-    </enumeratedValueSet>
-    <enumeratedValueSet variable="T">
-      <value value="1"/>
-    </enumeratedValueSet>
-  </experiment>
-</experiments>
 @#$#@#$#@
 @#$#@#$#@
 default

--- a/Sample Models/Chemistry & Physics/Unverified/Osmotic Pressure.nlogo
+++ b/Sample Models/Chemistry & Physics/Unverified/Osmotic Pressure.nlogo
@@ -1036,29 +1036,6 @@ NetLogo 5.2.0
 @#$#@#$#@
 @#$#@#$#@
 @#$#@#$#@
-<experiments>
-  <experiment name="experiment" repetitions="7" runMetricsEveryStep="false">
-    <setup>setup</setup>
-    <go>go</go>
-    <timeLimit steps="3000"/>
-    <metric>split</metric>
-    <metric>mean membrane-list</metric>
-    <metric>count solutes with [pxcor &lt; split]</metric>
-    <enumeratedValueSet variable="Solute_Type">
-      <value value="&quot;Sugar&quot;"/>
-      <value value="&quot;Sodium Chloride&quot;"/>
-      <value value="&quot;Magnesium Chloride&quot;"/>
-      <value value="&quot;Aluminum Chloride&quot;"/>
-    </enumeratedValueSet>
-    <enumeratedValueSet variable="solute-left">
-      <value value="50"/>
-      <value value="100"/>
-    </enumeratedValueSet>
-    <enumeratedValueSet variable="solute-right">
-      <value value="25"/>
-    </enumeratedValueSet>
-  </experiment>
-</experiments>
 @#$#@#$#@
 @#$#@#$#@
 default

--- a/Sample Models/Computer Science/K-Means Clustering.nlogo
+++ b/Sample Models/Computer Science/K-Means Clustering.nlogo
@@ -675,22 +675,6 @@ NetLogo 5.2.0
 @#$#@#$#@
 @#$#@#$#@
 @#$#@#$#@
-<experiments>
-  <experiment name="experiment" repetitions="100" runMetricsEveryStep="false">
-    <setup>setup</setup>
-    <go>go</go>
-    <timeLimit steps="20"/>
-    <metric>ticks</metric>
-    <enumeratedValueSet variable="no-of-data-points">
-      <value value="100"/>
-      <value value="1000"/>
-    </enumeratedValueSet>
-    <enumeratedValueSet variable="k-clusters">
-      <value value="4"/>
-      <value value="9"/>
-    </enumeratedValueSet>
-  </experiment>
-</experiments>
 @#$#@#$#@
 @#$#@#$#@
 default

--- a/src/test/scala/org/nlogo/models/BehaviorSpaceTests.scala
+++ b/src/test/scala/org/nlogo/models/BehaviorSpaceTests.scala
@@ -1,0 +1,26 @@
+package org.nlogo.models
+
+import scala.util.Try
+
+class BehaviorSpaceTests extends TestModels {
+
+  testModels("BehaviorSpace experiments XML should be well formed") { models =>
+    for {
+      model <- models
+      if model.behaviorSpace.nonEmpty
+      error <- Try(model.behaviorSpaceXML).failed.toOption
+      if !error.isInstanceOf[UnsupportedOperationException]
+    } yield model.quotedPath + "\n  " + error
+  }
+
+  testModels("BehaviorSpace experiment names should not start with \"experiment\"") { models =>
+    for {
+      model <- models
+      if model.behaviorSpace.nonEmpty
+      xml = model.behaviorSpaceXML
+      experimentNames = (xml \ "experiment" \ "@name").map(_.text)
+      badExperimentNames = experimentNames.filter(_.startsWith("experiment"))
+      if badExperimentNames.nonEmpty
+    } yield model.quotedPath + ":\n" + badExperimentNames.map("  " + _).mkString("\n")
+  }
+}

--- a/src/test/scala/org/nlogo/models/Info.scala
+++ b/src/test/scala/org/nlogo/models/Info.scala
@@ -43,20 +43,20 @@ object Info {
   }
   def fromContent(content: String): Info = {
     val contentLines = clean(content).lines.toSeq
-    val legalSnippet = contentLines.last
-    fromSections(contentToSections(contentLines.init), legalSnippet)
+    val legalSnippet = contentLines.lastOption
+    fromSections(contentToSections(contentLines.dropRight(1)), legalSnippet)
   }
-  def fromSections(sections: Iterable[(String, String)], legalSnippet: String): Info = {
+  def fromSections(sections: Iterable[(String, String)], legalSnippet: Option[String]): Info = {
     val content = sections
       .map { case (title, text) => s"## $title\n\n$text" }
       .mkString("", "\n\n", "\n\n") +
-      legalSnippet + "\n"
+      legalSnippet.getOrElse("") + "\n"
     Info(content, sections, legalSnippet)
   }
 }
 case class Info(
   val content: String,
   val sections: Iterable[(String, String)],
-  val legalSnippet: String) {
+  val legalSnippet: Option[String]) {
   val sectionMap: ListMap[String, String] = ListMap() ++ sections
 }

--- a/src/test/scala/org/nlogo/models/LegalInfo.scala
+++ b/src/test/scala/org/nlogo/models/LegalInfo.scala
@@ -88,7 +88,7 @@ case class LegalInfo(model: Model) {
   import LegalInfo._
 
   val (year: Int, year2: Option[Int], keywords: List[String], cite: String) = {
-    val pattern(y1, y2, keys, _, cite) = model.info.legalSnippet
+    val Some(pattern(y1, y2, keys, _, cite)) = model.info.legalSnippet
     (y1.toInt,
       if (y2 == null) None else Some(y2.trim.toInt),
       if (keys == null) List() else keys.split("""\s""").map(_.trim).filter(!_.isEmpty).toList,

--- a/src/test/scala/org/nlogo/models/Model.scala
+++ b/src/test/scala/org/nlogo/models/Model.scala
@@ -2,14 +2,13 @@ package org.nlogo.models
 
 import java.io.File
 import java.util.regex.Pattern.quote
-
 import scala.collection.JavaConverters.collectionAsScalaIterableConverter
-
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.FileUtils.listFiles
 import org.apache.commons.io.FileUtils.readFileToString
 import org.apache.commons.io.FilenameUtils.getExtension
 import org.apache.commons.io.FilenameUtils.removeExtension
+import scala.xml.XML
 
 object Model {
   sealed abstract trait UpdateMode
@@ -88,4 +87,5 @@ case class Model(
     if (name.endsWith(" 3D"))
       name.replaceFirst(" 3D$", "")
     else name
+    def behaviorSpaceXML = XML.loadString(behaviorSpace)
 }

--- a/src/test/scala/org/nlogo/models/VersionTests.scala
+++ b/src/test/scala/org/nlogo/models/VersionTests.scala
@@ -17,12 +17,15 @@ class VersionTests extends FunSuite {
 
   test("All models are readable") {
     if (allModelFailures.nonEmpty) fail(
-      allModelFailures.map {
-        case (f, e) =>
-          "\"" + f.getCanonicalPath + "\"\n  " +
-            e + "\n" +
-            e.getStackTrace.mkString("\n")
-      }.mkString("\n")
+      "The following models failed:" +
+        allModelFailures.map { case (f, e) => "  \"" + f.getCanonicalPath + "\"" }.mkString("\n") +
+        "Details:\n" +
+        allModelFailures.map {
+          case (f, e) =>
+            "\"" + f.getCanonicalPath + "\"\n" +
+              e + "\n" +
+              e.getStackTrace.mkString("\n")
+        }.mkString("\n\n")
     )
   }
 


### PR DESCRIPTION
- adds a test to detect experiments named `"experiment*"`;
- removes some irrelevant experiments;
- rename one relevant experiment.

Closes #62.