### PR TITLE
Make blue the last turtle instead of third last

### DIFF
--- a/Sample Models/Biology/Ant Lines.nlogo
+++ b/Sample Models/Biology/Ant Lines.nlogo
@@ -46,7 +46,7 @@ to setup
   ask turtles
     [ setxy nest-x nest-y                          ;; start the ants out at the nest
       set heading 90 ]
-  ask turtle (num-ants - 1)
+  ask turtle max [who] of turtles
     [ set color blue                               ;; last ant is blue
       set pen-size 2
       pd ]                                         ;; ...and leaves a trail


### PR DESCRIPTION
Using indices makes blue the third last ant (code bug?) instead of the last one as explained in the info tab.
PROPOSAL: use (max [who] of turtles) instead of (num-ants - 1)