### PR TITLE
Speed up model compilation tests

### DIFF
--- a/src/main/scala/org/nlogo/models/Model.scala
+++ b/src/main/scala/org/nlogo/models/Model.scala
@@ -32,10 +32,7 @@ object Model {
     m <- Try(apply(f)).toOption
   } yield m
 
-  val libraryModels: Iterable[Model] = {
-    val testPath = new File("test/").getCanonicalPath
-    allModels.filterNot(_.file.getCanonicalPath.startsWith(testPath))
-  }
+  val libraryModels: Iterable[Model] = allModels.filterNot(_.isTestModel)
 
   def apply(file: File): Model = {
     val content = readFileToString(file, "UTF-8")
@@ -75,6 +72,7 @@ case class Model(
   def save() = FileUtils.write(file, content, "UTF-8")
   def needsManualPreview = previewCommands.toLowerCase.contains(manualPreview)
   def is3d = getExtension(file.getName) == "nlogo3d"
+  def isTestModel = file.getCanonicalPath.startsWith(new File("test/").getCanonicalPath)
   def updateMode: UpdateMode =
     if (interface.lines
       .dropWhile(_ != "GRAPHICS-WINDOW")

--- a/src/test/scala/org/nlogo/models/TestModels.scala
+++ b/src/test/scala/org/nlogo/models/TestModels.scala
@@ -16,7 +16,8 @@ trait TestModels extends FunSuite {
         model <- models
         failures = testFun(model)
         if failures.nonEmpty
-      } yield model.quotedPath + failures.mkString("\n  ", "\n  ", "\n")
+      } yield model.quotedPath + "\n" +
+        failures.mkString("\n").lines.map("  " + _).mkString("\n")
       if (allFailures.nonEmpty) fail(allFailures.mkString("\n"))
     }
 


### PR DESCRIPTION
by reusing the same workspace to test everything that we want to test about a model's compiler output.