### PR TITLE
Ising: use `no-display` instead of `repeat` to speed up model

### DIFF
--- a/Sample Models/Chemistry & Physics/Ising.nlogo
+++ b/Sample Models/Chemistry & Physics/Ising.nlogo
@@ -21,12 +21,12 @@ to setup
 end
 
 to go
-  ;; update 1000 patches at a time
-  repeat 1000 [
-    ask one-of patches [ update ]
+  ask one-of patches [ update ]
+  if ticks mod 1000 = 0 [
+    display    ;; update the view once every 1000 ticks
+    no-display ;; and then turn off display updates to speed up the model
   ]
-  tick-advance 1000  ;; use `tick-advance`, as we are updating 1000 patches at a time
-  update-plots       ;; unlike `tick`, `tick-advance` doesn't update the plots, so we need to do so explicitly
+  tick
 end
 
 ;; update the spin of a single patch
@@ -595,7 +595,7 @@ Polygon -7500403 true true 270 75 225 30 30 225 75 270
 Polygon -7500403 true true 30 75 75 30 270 225 225 270
 
 @#$#@#$#@
-NetLogo 5.2.0
+NetLogo 5.2.1-M3
 @#$#@#$#@
 @#$#@#$#@
 @#$#@#$#@


### PR DESCRIPTION
I found a different way to speed up the Ising model: instead of using `repeat 1000` and then `ticks-advance 1000`, I use `no-display` to turn off view updates and explicitly call `display` every 1000 ticks.

This is, in my opinion, a much less convoluted way to achieve the desired result. It also means that `go` runs once per tick instead of once every 1000 ticks, which is more intuitive.

@UriCCL, @arthurhjorth, @qiemem, what do you think? Unless someone has an objection, I will update the info tab accordingly and merge the changes.

(@UriCCL, here is the direct link for downloading the updated model if you want to check it out: https://raw.githubusercontent.com/NetLogo/models/ising-no-display/Sample%20Models/Chemistry%20%26%20Physics/Ising.nlogo )