### PR TITLE
Eliminate use of `no-display`

### DIFF
--- a/Curricular Models/ProbLab/4 Block Stalagmites.nlogo
+++ b/Curricular Models/ProbLab/4 Block Stalagmites.nlogo
@@ -34,24 +34,30 @@ sample-organizers-own [
   original-pycor
 ]
 
-to go-org
+to go
   if stop-all? [ stop ]
-  super-go
-  organize-results
+
+  let popped? popping?
+  if popped? [ unpop ]
+
+  ;; The model keeps track of which different combinations have been
+  ;; discovered. Each column-kid reports whether or not its column has
+  ;; all the possible combinations. When bound? is true, a report from
+  ;; ALL column-kids that their columns are full will stop the run.
+  if stop-at-all-found? and all? column-kids [ column-full? ] [
+    stop
+  ]
+  sample
+  ifelse magnify? [ magnify-on-side ] [ ask baby-dudes [ die ] ]
+  drop-in-bin
+
+  if popped? [ pop ]
+  tick
 end
 
-to super-go
-  if stop-all? [ stop ]
-  ifelse popping? [
-    no-display
-    unpop
-    go
-    pop
-    display
-  ] [
-    go
-    display
-  ]
+to go-org
+  go
+  organize-results
 end
 
 ;; the popping? global controls the popping visuals
@@ -254,22 +260,6 @@ to setup
   set stop-all? false
   set num-target-color false
   reset-ticks
-end
-
-to go
-  if stop-all? [ stop ]
-  ;; The model keeps track of which different combinations have been
-  ;; discovered. Each column-kid reports whether or not its column has
-  ;; all the possible combinations. When bound? is true, a report from
-  ;; ALL column-kids that their columns are full will stop the run.
-  if stop-at-all-found? and all? column-kids [ column-full? ] [
-    stop
-  ]
-  sample
-  ifelse magnify? [ magnify-on-side ] [ ask baby-dudes [ die ] ]
-  drop-in-bin
-
-  tick
 end
 
 to-report column-full?
@@ -541,7 +531,7 @@ BUTTON
 265
 103
 Go
-super-go
+go
 T
 1
 T
@@ -619,7 +609,7 @@ BUTTON
 135
 103
 Go Once
-super-go
+go
 NIL
 1
 T

--- a/Curricular Models/ProbLab/4 Block Stalagmites.nlogo
+++ b/Curricular Models/ProbLab/4 Block Stalagmites.nlogo
@@ -270,7 +270,6 @@ to go
   drop-in-bin
 
   tick
-  if plot? [ histogram-blocks ]
 end
 
 to-report column-full?
@@ -488,27 +487,6 @@ end
 
 to-report total-samples-to-find
   report precision (2 ^ (side ^ 2)) 0
-end
-
-to histogram-blocks
-  let sample-value-summaries [ sample-summary-value ] of sample-organizers
-  let possible-values n-values (2 ^ (side * side)) [ ? ]
-  let results []
-  foreach possible-values [
-    let i ?
-    set results lput length filter [ ? = i ] sample-value-summaries results
-  ]
-
-  set-current-plot "Events by Number of Outcomes"
-  let max-results max results
-  if mean results > 0 [ set-plot-x-range 0 (max-results + 1) ]
-  set-current-plot-pen "Histogram"
-  histogram results
-  set-current-plot-pen "Mean"
-  let mean-results mean results
-  plot-pen-reset
-  plotxy mean-results 0
-  plotxy mean-results plot-y-max
 end
 
 
@@ -751,7 +729,7 @@ Number of Outcomes per Event
 15.0
 true
 false
-"" ""
+"" "if plot? [\n  let sample-value-summaries [ sample-summary-value ] of sample-organizers\n  let possible-values n-values (2 ^ (side * side)) [ ? ]\n  let results []\n  foreach possible-values [\n    let i ?\n    set results lput length filter [ ? = i ] sample-value-summaries results\n  ]\n\n  let max-results max results\n  if mean results > 0 [ set-plot-x-range 0 (max-results + 1) ]\n  set-current-plot-pen \"Histogram\"\n  histogram results\n  set-current-plot-pen \"Mean\"\n  let mean-results mean results\n  plot-pen-reset\n  plotxy mean-results 0\n  plotxy mean-results plot-y-max\n]"
 PENS
 "histogram" 1.0 1 -16777216 true "" ""
 "Mean" 1.0 0 -2674135 true "" ""

--- a/Curricular Models/ProbLab/4 Block Stalagmites.nlogo
+++ b/Curricular Models/ProbLab/4 Block Stalagmites.nlogo
@@ -543,9 +543,9 @@ ticks
 30.0
 
 SLIDER
-300
+285
 570
-529
+535
 603
 probability-to-be-target-color
 probability-to-be-target-color

--- a/Curricular Models/ProbLab/4 Block Two Stalagmites.nlogo
+++ b/Curricular Models/ProbLab/4 Block Two Stalagmites.nlogo
@@ -49,12 +49,9 @@ sample-organizers-own [
   original-pycor
 ]
 
-to go-org
-  super-go
-  organize-results
-end
 
-to super-go
+to go
+
   if stop-all? [
     ifelse stop-at-top? [
       stop
@@ -62,17 +59,27 @@ to super-go
       bump-down
     ]
   ]
-  ifelse popping? [
-    no-display
-    unpop
-    go
-    pop
-    display
-  ] [
-    go
-    display
-  ]
+
+  let popped? popping?
+  if popped? [ unpop ]
+
+  ;; The model keeps track of which different combinations
+  ;; have been discovered. Each column-kid reports whether
+  ;; or not its column has all the possible combinations.
+  ;; When bound? is true, a report from ALL column-kids
+  ;; that their columns are full will stop the run.
+  sample
+  drop-in-bin
+
+  if popped? [ pop ]
+
+  tick
   plot-it
+end
+
+to go-org
+  go
+  organize-results
 end
 
 ;; global controls the popping visuals
@@ -323,17 +330,6 @@ to bump-down
   ask sample-organizers [ fd 3 ]
   ask left-dummies [ fd 3 ]
   recolor-columns
-end
-
-to go
-  ;; The model keeps track of which different combinations
-  ;; have been discovered. Each column-kid reports whether
-  ;; or not its column has all the possible combinations.
-  ;; When bound? is true, a report from ALL column-kids
-  ;; that their columns are full will stop the run.
-  sample
-  drop-in-bin
-  tick
 end
 
 ;; This procedure creates a square sample of dimensions
@@ -661,7 +657,7 @@ BUTTON
 245
 128
 Go
-super-go
+go
 T
 1
 T
@@ -678,7 +674,7 @@ BUTTON
 165
 128
 Go Once
-super-go
+go
 NIL
 1
 T
@@ -693,7 +689,7 @@ BUTTON
 10
 135
 165
-166
+168
 Organize Results
 organize-results
 NIL

--- a/Curricular Models/Urban Suite/Urban Suite - Tijuana Bordertowns.nlogo
+++ b/Curricular Models/Urban Suite/Urban Suite - Tijuana Bordertowns.nlogo
@@ -866,7 +866,7 @@ BUTTON
 70
 43
 1  clear
-clear-all\nwithout-interruption\n[ no-display\nclear-all\nask patches [ set pcolor white ]\ndisplay ]\nreset-ticks
+clear-all\nask patches [ set pcolor white ]\nreset-ticks
 NIL
 1
 T
@@ -1631,7 +1631,7 @@ Polygon -7500403 true true 270 75 225 30 30 225 75 270
 Polygon -7500403 true true 30 75 75 30 270 225 225 270
 
 @#$#@#$#@
-NetLogo 5.2.1
+NetLogo 5.2.1-RC1
 @#$#@#$#@
 ask patches [ set pcolor white ]
 reset-ticks

--- a/HubNet Activities/Unverified/Oil Cartel Alternate HubNet.nlogo
+++ b/HubNet Activities/Unverified/Oil Cartel Alternate HubNet.nlogo
@@ -123,10 +123,12 @@ end
 to run-market
   if (market-running? != true) [ plot-supply-and-demand ]
 
-  ;; Turn off the display if needed
-  ifelse (perfect-information? = true)
-    [ display ]
-    [ no-display ]
+  ;; Hide buyers when perfect information is turned off
+  ask buyers [ set hidden? not perfect-information? ]
+
+  ;; Since there is no `setup` procedure where `reset-ticks` could be
+  ;; called in this model, we have to use `display` instead of `tick`.
+  display
 
   set market-running? true
 
@@ -1457,7 +1459,7 @@ Polygon -7500403 true true 270 75 225 30 30 225 75 270
 Polygon -7500403 true true 30 75 75 30 270 225 225 270
 
 @#$#@#$#@
-NetLogo 5.2.0
+NetLogo 5.2.1-RC1
 @#$#@#$#@
 need-to-manually-make-preview-for-this-model
 @#$#@#$#@

--- a/src/test/scala/org/nlogo/models/CodeTests.scala
+++ b/src/test/scala/org/nlogo/models/CodeTests.scala
@@ -84,6 +84,7 @@ class CodeTests extends TestModels {
     "ht" -> Seq.empty,
     "in-cone-nowrap" -> Seq.empty,
     "in-radius-nowrap" -> Seq.empty,
+    "no-display" -> Seq.empty,
     "pd" -> Seq.empty,
     "ppd" -> Seq.empty,
     "ppu" -> Seq.empty,


### PR DESCRIPTION
@SethTisue points out in https://github.com/NetLogo/models/pull/131#issuecomment-142038737 that the use of `no-display` should be avoided in the Models Library.

As 9437660 reveals, it is currently used in the following (curricular) models:

```
[info] - Forbidden primitives are not used *** FAILED ***
[info]   "/media/data/Dropbox (SESP)/w/nl5/models/HubNet Activities/Unverified/Oil Cartel Alternate HubNet.nlogo"
[info]     uses no-display
[info]   "/media/data/Dropbox (SESP)/w/nl5/models/Curricular Models/ProbLab/4 Block Stalagmites.nlogo"
[info]     uses no-display
[info]   "/media/data/Dropbox (SESP)/w/nl5/models/Curricular Models/ProbLab/4 Block Two Stalagmites.nlogo"
[info]     uses no-display (TestModels.scala:21)
```

I'll see if I can weed it out.