### PR TITLE
Geometron Top-Down: make sure `type-a?`is initialized

### DIFF
--- a/Sample Models/Art/Unverified/Geometron Top-Down.nlogo
+++ b/Sample Models/Art/Unverified/Geometron Top-Down.nlogo
@@ -16,6 +16,7 @@ to setup
   ask turtles
     [pen-down
      set new? false
+     set type-a? false
     ]
   set curr-color-sep color-sep
   set counter 0
@@ -1161,7 +1162,7 @@ Polygon -7500403 true true 270 75 225 30 30 225 75 270
 Polygon -7500403 true true 30 75 75 30 270 225 225 270
 
 @#$#@#$#@
-NetLogo 5.2.1-M3
+NetLogo 5.2.1-RC1
 @#$#@#$#@
 setup
 ask turtles [ repeat 50 [ pattern-1 ] ]


### PR DESCRIPTION
...and thereby avoid runtime errors when checking
`if type-a?` when it is equal to zero, fixing #145.