### PR TITLE
Wolf Sheep Predation: set grass before setup in preview commands

### DIFF
--- a/Sample Models/Biology/Wolf Sheep Predation.nlogo
+++ b/Sample Models/Biology/Wolf Sheep Predation.nlogo
@@ -817,8 +817,8 @@ Polygon -7500403 true true 30 75 75 30 270 225 225 270
 @#$#@#$#@
 NetLogo 5.2.0
 @#$#@#$#@
-setup
 set grass? true
+setup
 repeat 75 [ go ]
 @#$#@#$#@
 @#$#@#$#@


### PR DESCRIPTION
Not sure if this counts as a bug or not. (I don't think I would ever have noticed if I wasn't working on the Preview Commands editor - https://github.com/NetLogo/NetLogo/pull/886). It does seem worth documenting a bit, though.

The old preview commands for Wolf-Sheep were:
```
setup
set grass? true
repeat 75 [ go ]
```

The behavior of `setup` is affected by the value of `grass?`. When you load the model, `grass?` is `false`. When you run the preview commands once, `grass?` turns to `true`. The value of `grass?` is not affected by any subsequent call to `clear-all` since `grass?` is a switch, so when you run the commands a second time, you get a different result. Running the commands again and again then gives the same result as the second time since `grass?` is always `true` from now on.

Does it matter? I don't know. Preview commands are meant to be run only once, but my gut feeling is that they should always be idempotent nonetheless. And it would be easy to test for that once model tests are based off a build that includes https://github.com/NetLogo/NetLogo/pull/886.

Anyway, changing the commands to
```
set grass? true
setup
repeat 75 [ go ]
```

fixes it for Wolf-Sheep.