### PR TITLE
Flocking models: initialize `flockmates` to `no-turtles`

### DIFF
--- a/3D/Sample Models/Flocking 3D Alternate.nlogo3d
+++ b/3D/Sample Models/Flocking 3D Alternate.nlogo3d
@@ -23,6 +23,7 @@ to setup
       set velocity [ 0 0 0 ]
       set acceleration [ 0 0 0 ]
       set color yellow + 2 - random-float 6
+      set flockmates no-turtles
     ]
   ask turtle 0 [ set color red ]
 

--- a/3D/Sample Models/Flocking 3D.nlogo3d
+++ b/3D/Sample Models/Flocking 3D.nlogo3d
@@ -16,7 +16,7 @@ to setup
       right random-float 360
       tilt-up asin (1.0 - random-float 2.0)
       roll-right random-float 360
-      ]
+      set flockmates no-turtles ]
   ask turtle 0 [ set color red ]
   reset-ticks
 end

--- a/Alternative Visualizations/Flocking - Alternative Visualizations.nlogo
+++ b/Alternative Visualizations/Flocking - Alternative Visualizations.nlogo
@@ -14,7 +14,8 @@ to setup
       if first question != "D"
         [ set color yellow - 2 + random 7 ]  ;; random shades look nice
       setxy random-xcor random-ycor
-      rt random-float 360 ]
+      rt random-float 360
+      set flockmates no-turtles ]
   reset-ticks
 end
 

--- a/Code Examples/Perspective Demos/Flocking (Perspective Demo).nlogo
+++ b/Code Examples/Perspective Demos/Flocking (Perspective Demo).nlogo
@@ -8,7 +8,8 @@ to setup
   create-turtles population
     [ set color yellow - 2 + random 7  ;; random shades look nice
       set size 1.5  ;; easier to see
-      setxy random-xcor random-ycor ]
+      setxy random-xcor random-ycor
+      set flockmates no-turtles ]
   ask patches
     [ set pcolor green - random 2 ]
   reset-ticks
@@ -672,7 +673,7 @@ Polygon -7500403 true true 270 75 225 30 30 225 75 270
 Polygon -7500403 true true 30 75 75 30 270 225 225 270
 
 @#$#@#$#@
-NetLogo 5.2.1
+NetLogo 5.2.0
 @#$#@#$#@
 need-to-manually-make-preview-for-this-model
 @#$#@#$#@

--- a/Sample Models/Biology/Flocking.nlogo
+++ b/Sample Models/Biology/Flocking.nlogo
@@ -8,7 +8,8 @@ to setup
   create-turtles population
     [ set color yellow - 2 + random 7  ;; random shades look nice
       set size 1.5  ;; easier to see
-      setxy random-xcor random-ycor ]
+      setxy random-xcor random-ycor
+      set flockmates no-turtles ]
   reset-ticks
 end
 


### PR DESCRIPTION
To prevent expressions like `mean [count flockmates + 1] of turtles` from
breaking right after setup. 

See:
http://stackoverflow.com/questions/34010615/how-do-i-use-the-primitives-no-patches-no-links-no-turtles/34010920?noredirect=1#comment55786047_34010920