### PR TITLE
Allow running all tests for (most) models using extensions

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,2 +1,0 @@
--Dorg.nlogo.noGenerator=true
--Xmx2G

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   - $HOME/.ivy2
   - $HOME/.sbt/boot
   - $HOME/.sbt/launchers
+  - $HOME/.sbt/0.13/staging
 addons:
   apt:
     packages:
@@ -18,6 +19,9 @@ jdk:
 script:
   - ./sbt test
   - ./sbt test -Dorg.nlogo.is3d=true
+  # Tricks to avoid unnecessary cache updates (see http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html)
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
 notifications:
   email:
     - nicolaspayette@gmail.com

--- a/build.sbt
+++ b/build.sbt
@@ -4,16 +4,32 @@ scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation")
 
 resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
 
+javaOptions ++= Seq(
+  "-Dorg.nlogo.is3d=" + Option(System.getProperty("org.nlogo.is3d")).getOrElse("false"),
+  "-Dnetlogo.extensions.dir=" + (baseDirectory in netLogo).value.getPath + "/extensions/",
+  "-Dcom.sun.media.jai.disableMediaLib=true", // see https://github.com/NetLogo/GIS-Extension/issues/4
+  "-Xmx2G" // extra memory to work around https://github.com/travis-ci/travis-ci/issues/3775
+)
+
+fork := true
+
 libraryDependencies ++= Seq(
-  "org.nlogo" % "NetLogo" % "5.3.0" from
-    "http://ccl.northwestern.edu/devel/NetLogo-5.3-17964bb.jar",
-  "asm" % "asm-all" % "3.3.1",
-  "org.picocontainer" % "picocontainer" % "2.13.6",
   "org.scalatest" %% "scalatest" % "2.2.4" % Test,
   "commons-io" % "commons-io" % "2.4",
   "commons-validator" % "commons-validator" % "1.4.1",
   "com.typesafe.play" %% "play-ws" % "2.3.8",
-  "org.pegdown" % "pegdown" % "1.1.0",
   "com.github.wookietreiber" %% "scala-chart" % "0.4.2",
-  "org.jfree" % "jfreesvg" % "3.0"
+  "org.jfree" % "jfreesvg" % "3.0",
+  "org.scalactic" % "scalactic_2.11" % "2.2.4"
 )
+
+(test in Test) <<= (test in Test) dependsOn {
+  Def.task {
+    EvaluateTask(
+      buildStructure.value,
+      extensionsKey,
+      state.value,
+      buildStructure.value.allProjectRefs.find(_.project.contains("NetLogo")).get
+    )
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,0 +1,12 @@
+import sbt._
+
+object MyBuild extends Build {
+
+  lazy val netLogo = RootProject(uri("git://github.com/NetLogo/NetLogo.git#hexy-extensions-task"))
+
+  lazy val root = Project("root", file("."))
+    .dependsOn(netLogo)
+
+  lazy val extensionsKey =
+    Def.ScopedKey[Task[Seq[File]]](Scope(This, This, This, This) in netLogo, AttributeKey[Task[Seq[File]]]("extensions"))
+}

--- a/src/main/scala/org/nlogo/models/Model.scala
+++ b/src/main/scala/org/nlogo/models/Model.scala
@@ -106,4 +106,27 @@ case class Model(
   def primitiveTokenNames: Seq[String] = tokens
     .filter(t => t.tyype == REPORTER || t.tyype == COMMAND || t.tyype == VARIABLE)
     .map(_.name)
+
+  lazy val isCompilable: Boolean = {
+    val neverCompilable = Set(
+      "GoGoMonitorSerial",
+      "GoGoMonitorSimpleSerial",
+      "QuickTime Movie Example",
+      "QuickTime Camera Example",
+      "Arduino Example"
+    ) // because they use extensions unbundled in hexy
+    val notCompilableOnTravis = Set(
+      "Beatbox",
+      "Composer",
+      "GasLab With Sound",
+      "Musical Phrase Example",
+      "Percussion Workbench",
+      "Sound Workbench",
+      "Sound Machines",
+      "Frogger",
+      "Sound Machines"
+    ) // because MIDI is not available on Travis
+    !(neverCompilable.contains(name) || (onTravis && notCompilableOnTravis.contains(name)))
+  }
+
 }

--- a/src/main/scala/org/nlogo/models/package.scala
+++ b/src/main/scala/org/nlogo/models/package.scala
@@ -3,6 +3,9 @@ package org.nlogo
 import org.nlogo.headless.HeadlessWorkspace
 
 package object models {
+
+  lazy val onTravis: Boolean = sys.env.get("TRAVIS").filter(_.toBoolean).isDefined
+
   def withWorkspace[A](model: Model)(f: HeadlessWorkspace => A) = {
     val workspace = HeadlessWorkspace.newInstance
     try {

--- a/src/test/scala/org/nlogo/models/ModelCompilationTests.scala
+++ b/src/test/scala/org/nlogo/models/ModelCompilationTests.scala
@@ -12,10 +12,6 @@ import org.nlogo.headless.HeadlessWorkspace
 
 class ModelCompilationTests extends TestModels {
 
-  // models using extensions are excluded because our current
-  // setup makes it non-trivial to headlessly compile them
-  def excluded(model: Model) = model.code.lines.exists(_.startsWith("extensions"))
-
   def compilationTests(model: Model)(ws: HeadlessWorkspace): Iterable[String] =
     breedNamesUsedAsArgsOrVars(ws) ++
       breedsWithNoSingularName(ws) ++
@@ -26,12 +22,12 @@ class ModelCompilationTests extends TestModels {
       })
 
   testModels("Compilation output should satisfy various properties", includeTestModels = true) { model =>
-    if (excluded(model)) Seq.empty else {
+    if (model.isCompilable) {
       Try(withWorkspace(model)(compilationTests(model))) match {
         case Failure(error)  => Seq(error.toString)
         case Success(errors) => errors
       }
-    }
+    } else Seq.empty
   }
 
   def breedNamesUsedAsArgsOrVars(ws: HeadlessWorkspace): Iterable[String] = {


### PR DESCRIPTION
Instead of depending on `"org.nlogo" % "NetLogo" % "5.3.0" from "http://ccl.northwestern.edu/devel/NetLogo-5.3-17964bb.jar"`, the build now depends on `RootProject(uri("git://github.com/NetLogo/NetLogo.git#hexy-extensions-task"))`. This makes it possible to use NetLogo extensions from model tests and allow us to use the latest/greatest version of NetLogo (thus potentially catching regressions earlier).

A few notes:

- We currently depend on the `hexy-extensions-task` branch of NetLogo. That should be changed for `hexy` once https://github.com/NetLogo/NetLogo/pull/901 is merged.

- It seems like having `--Dorg.nlogo.noGenerator=true` interfered with the `profiler` extension, so it's now removed. Despite what I claimed in 79f896b7fa20b646d393f7ef486ff83e52c735c8, it seems like having the generator back on doesn't interfere with running tests in parallel. Maybe just forking the JVM was what fixed it then? In any case, it works.

- The `extensions` task from the NetLogo project currently runs on every `models` build, even if the extensions are already built. I have no idea how to fix that at the moment, but it's no big deal for now. I may require @mrerrormessage's sbt-fu again... :-)

