### PR TITLE
Urban Suite - Pollution: remove unused patch variable

### DIFF
--- a/Curricular Models/Urban Suite/Urban Suite - Pollution.nlogo
+++ b/Curricular Models/Urban Suite/Urban Suite - Pollution.nlogo
@@ -5,8 +5,11 @@ breed [ trees tree ]
 
 turtles-own [ health ]
 
-patches-own[ pollution
-             is-power-plant? ]
+patches-own [
+  pollution
+  is-power-plant?
+]
+
 to setup
   clear-all
   reset-ticks
@@ -33,8 +36,7 @@ to setup
 end
 
 to go
-  ask people
-  [
+  ask people [
     wander
     reproduce
     maybe-plant
@@ -42,66 +44,76 @@ to go
     maybe-die
   ]
 
-diffuse pollution 0.8
- ask patches [ pollute ]
+  diffuse pollution 0.8
 
- ask trees [ cleanup maybe-die ]
+  ask patches [ pollute ]
+  ask trees [
+    cleanup
+    maybe-die
+  ]
 
- if not any? people
-   [ stop ]
+  if not any? people [ stop ]
 
- do-plot
- tick
+  do-plot
+  tick
 end
 
 to create-power-plants
-  ask n-of power-plants patches [ set is-power-plant? true ]
+  ask n-of power-plants patches [
+    set is-power-plant? true
+  ]
 end
 
 to pollute  ;; patch procedure
-  if ( is-power-plant? )
-  [
+  if is-power-plant? [
     set pcolor red
     set pollution polluting-rate
   ]
-  set pcolor scale-color red ( pollution - .1 ) 5 0
+  set pcolor scale-color red (pollution - .1) 5 0
 end
 
 to cleanup  ;; tree procedure
-    set pcolor green + 3
-    set pollution max (list 0 ( pollution - 1 ) )
-    ask neighbors [ set pollution max (list 0 ( pollution - .5 ) ) ]
-    set health health - 0.1
+  set pcolor green + 3
+  set pollution max (list 0 (pollution - 1))
+  ask neighbors [
+    set pollution max (list 0 (pollution - .5))
+  ]
+  set health health - 0.1
 end
 
-to wander   ;; person procedure
+to wander  ;; person procedure
   rt random-float 50
   lt random-float 50
   fd 1
   set health health - 0.1
 end
 
-to reproduce ;; person procedure
-  if ( ( health > 4 ) and ( ( random-float 1 ) < birth-rate ) )
-    [ hatch-people 1 [ set health 5 ] ]
+to reproduce  ;; person procedure
+  if health > 4 and random-float 1 < birth-rate [
+    hatch-people 1 [
+      set health 5
+    ]
+  ]
 end
 
-to maybe-plant ;; person procedure
-  if ( ( random-float 1 ) < planting-rate )
-  [ hatch-trees 1 [ set health 5 set color green ] ]
+to maybe-plant  ;; person procedure
+  if random-float 1 < planting-rate [
+    hatch-trees 1 [
+      set health 5
+      set color green
+    ]
+  ]
 end
 
 to eat-pollution  ;; person procedure
-  if ( pollution > 0.5 )
-  [
+  if pollution > 0.5 [
     set health (health - (pollution / 10))
   ]
 end
 
 
-to maybe-die     ;;die if you run out of health
-  if ( health <= 0 )
-    [ die ]
+to maybe-die  ;; die if you run out of health
+  if health <= 0 [ die ]
 end
 
 to do-plot

--- a/Curricular Models/Urban Suite/Urban Suite - Pollution.nlogo
+++ b/Curricular Models/Urban Suite/Urban Suite - Pollution.nlogo
@@ -1,6 +1,4 @@
 breed [ people person ]
-
-; just used to make pretty graphics
 breed [ trees tree ]
 
 turtles-own [ health ]

--- a/Curricular Models/Urban Suite/Urban Suite - Pollution.nlogo
+++ b/Curricular Models/Urban Suite/Urban Suite - Pollution.nlogo
@@ -25,7 +25,7 @@ to setup
 
   create-people initial-population [
     set color black
-    randomize-position
+    setxy random-pxcor random-pycor
     set health 5
   ]
 
@@ -111,11 +111,6 @@ end
 
 to maybe-die  ;; die if you run out of health
   if health <= 0 [ die ]
-end
-
-to randomize-position
-  setxy random-float world-width
-        random-float world-height
 end
 
 

--- a/Curricular Models/Urban Suite/Urban Suite - Pollution.nlogo
+++ b/Curricular Models/Urban Suite/Urban Suite - Pollution.nlogo
@@ -6,8 +6,7 @@ breed [ trees tree ]
 turtles-own [ health ]
 
 patches-own[ pollution
-             is-power-plant?
-             is-tree? ]
+             is-power-plant? ]
 to setup
   clear-all
   reset-ticks

--- a/Curricular Models/Urban Suite/Urban Suite - Pollution.nlogo
+++ b/Curricular Models/Urban Suite/Urban Suite - Pollution.nlogo
@@ -12,7 +12,6 @@ patches-own [
 
 to setup
   clear-all
-  reset-ticks
 
   set-default-shape people "person"
   set-default-shape trees "tree"
@@ -32,10 +31,13 @@ to setup
     set health 5
   ]
 
-  do-plot
+  reset-ticks
 end
 
 to go
+
+  if not any? people [ stop ]
+
   ask people [
     wander
     reproduce
@@ -47,14 +49,12 @@ to go
   diffuse pollution 0.8
 
   ask patches [ pollute ]
+
   ask trees [
     cleanup
     maybe-die
   ]
 
-  if not any? people [ stop ]
-
-  do-plot
   tick
 end
 
@@ -111,18 +111,8 @@ to eat-pollution  ;; person procedure
   ]
 end
 
-
 to maybe-die  ;; die if you run out of health
   if health <= 0 [ die ]
-end
-
-to do-plot
-  set-current-plot-pen "trees"
-  plot count trees
-  set-current-plot-pen "people"
-  plot count people
-  set-current-plot-pen "pollution"
-  plot sum [pollution] of patches
 end
 
 to randomize-position
@@ -241,9 +231,9 @@ true
 true
 "" ""
 PENS
-"trees" 1.0 0 -10899396 true "" ""
-"people" 1.0 0 -2674135 true "" ""
-"pollution" 1.0 0 -8630108 true "" ""
+"trees" 1.0 0 -10899396 true "" "plot count trees"
+"people" 1.0 0 -2674135 true "" "plot count people"
+"pollution" 1.0 0 -8630108 true "" "plot sum [ pollution ] of patches"
 
 MONITOR
 195

--- a/Curricular Models/Urban Suite/Urban Suite - Pollution.nlogo
+++ b/Curricular Models/Urban Suite/Urban Suite - Pollution.nlogo
@@ -307,9 +307,13 @@ Trees, however, clean up pollution in the cell they are planted, and the neighbo
 Trees live for a set period of time and cannot reproduce.
 
 Each time step (tick) of the model, people agents
+
 1. move randomly to an adjacent cell
+
 2. with some probability, they may plant a landscape element
+
 3. if they are healthy enough, with some probability, they may reproduce (clone)
+
 4. if their health has dropped to 0, they die.
 
 ## HOW TO USE IT
@@ -348,7 +352,7 @@ Make the pollution rate dependent upon the number of people.
 
 ## NETLOGO FEATURES
 
-This model uses the DIFFUSE command to spread pollution.
+This model uses the `diffuse` command to spread pollution.
 
 ## RELATED MODELS
 


### PR DESCRIPTION
as @mrerrormessage reports, the variable was conflicting with the
compiler generated `is-tree?` reporter