### PR TITLE
Random Network (Example): ensure num-links not too big for num-nodes

### DIFF
--- a/Code Examples/Random Network Example.nlogo
+++ b/Code Examples/Random Network Example.nlogo
@@ -4,10 +4,18 @@ to setup-simple-random
   create-turtles num-nodes
   layout-circle turtles (max-pxcor - 1)
   ;; Now make links one at a time until we have enough
+  if num-links > max-links [ set num-links max-links ]
   while [count links < num-links] [
     ;; Note that if the link already exists, nothing happens
     ask one-of turtles [ create-link-with one-of other turtles ]
   ]
+end
+
+to-report max-links
+  ;; report the maximum number of links that can be added
+  ;; to a random network, given the specified number
+  ;; of nodes, with 1000 as an arbitrary upper bound
+  report min (list (num-nodes * (num-nodes - 1) / 2) 1000)
 end
 
 to setup-erdos-renyi
@@ -99,7 +107,7 @@ SLIDER
 num-links
 num-links
 0
-100
+max-links
 25
 1
 1
@@ -141,7 +149,7 @@ num-nodes
 num-nodes
 2
 500
-24
+25
 1
 1
 NIL

--- a/IABM Textbook/chapter 5/Random Network.nlogo
+++ b/IABM Textbook/chapter 5/Random Network.nlogo
@@ -34,11 +34,19 @@ end
 ;; It uses WHILE to ensure we get NUM-LINKS links.
 to wire3
   ask links [ die ]
+  if num-links > max-links [ set num-links max-links ]
   while [ count links < num-links ] [
     ask one-of turtles [
       create-link-with one-of other turtles
     ]
   ]
+end
+
+;; Report the maximum number of links that can be added
+;; to a random network, given the specified number
+;; of nodes, with 1000 as an arbitrary upper bound
+to-report max-links
+  report min (list (num-nodes * (num-nodes - 1) / 2) 1000)
 end
 
 ;; A variant of the classic Erdős-Rényi where each possible pair of nodes
@@ -125,7 +133,7 @@ SLIDER
 num-links
 num-links
 0
-min (list (num-nodes * (num-nodes - 1) / 2) 1000)
+max-links
 100
 1
 1


### PR DESCRIPTION
Fixes #238.

Using both of Alan's suggested solutions together fully fixes the problem. Having a dynamic slider upper bound for `num-links` is very nice, but doesn't cover the case where `num-nodes` is decreased _after_ `max-links` has been set to a high number. Adding `if num-links > max-links [ set num-links max-links ]` in the code takes care of that.