### PR TITLE
Rebellion: avoid `agent` as singular breed name

### DIFF
--- a/Sample Models/Social Science/Rebellion.nlogo
+++ b/Sample Models/Social Science/Rebellion.nlogo
@@ -1,4 +1,4 @@
-breed [agents agent]
+breed [agents an-agent]
 breed [cops cop]
 
 globals [


### PR DESCRIPTION
to prevent shadowing `is-agent?` (following https://github.com/NetLogo/NetLogo/pull/920)