### PR TITLE
Update tests for latest version of hexy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -487,3 +487,5 @@ Curricular Models/BEAGLE Evolution/aquarium.jpg
 Curricular Models/BEAGLE Evolution/glacier.jpg
 Curricular Models/BEAGLE Evolution/poppyfield.jpg
 Curricular Models/BEAGLE Evolution/seashore.jpg
+/.cache-main
+/.cache-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 cache:
   apt: true
   directories:

--- a/src/main/scala/org/nlogo/models/package.scala
+++ b/src/main/scala/org/nlogo/models/package.scala
@@ -18,6 +18,8 @@ import org.nlogo.headless.HeadlessWorkspace
 import org.nlogo.models.InfoTabParts
 
 package object models {
+  
+  org.nlogo.headless.Main.setHeadlessProperty()
 
   lazy val onTravis: Boolean = sys.env.get("TRAVIS").filter(_.toBoolean).isDefined
 

--- a/src/test/scala/org/nlogo/models/ModelCompilationTests.scala
+++ b/src/test/scala/org/nlogo/models/ModelCompilationTests.scala
@@ -64,7 +64,7 @@ class ModelCompilationTests extends TestModels {
   def uncompilableExperiments(model: Model, ws: HeadlessWorkspace): Iterable[String] = {
     val lab = HeadlessWorkspace.newLab
     for {
-      experiment <- BehaviorSpaceCoordinator.protocolsFromModel(model.file.getPath)
+      experiment <- BehaviorSpaceCoordinator.protocolsFromModel(model.file.getPath, ws)
       error <- Try(lab.newWorker(experiment).compile(ws)).failed.toOption
     } yield s"BehaviorSpace experiment '$experiment' does not compile: $error"
   }


### PR DESCRIPTION
Just keeping up with the recent changes.

Notably, this switches back to the regular Travis environment (with `sudo: required`) because the random Travis failures where becoming more frequent.