### PR TITLE
Check-out of GenEvo (1-4) models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,10 +102,10 @@ target/
 /Curricular Models/BEAGLE Evolution/HubNet Activities/Bug Hunters Camouflage HubNet.nlogo
 /Curricular Models/BEAGLE Evolution/Mimicry.nlogo
 /Curricular Models/BEAGLE Evolution/Wolf Sheep Predation.nlogo
-/Curricular Models/GenEvo/GenEvo 1 Genetic Switch.nlogo
-/Curricular Models/GenEvo/GenEvo 2 Genetic Drift.nlogo
-/Curricular Models/GenEvo/GenEvo 3 Genetic Drift and Natural Selection.nlogo
-/Curricular Models/GenEvo/GenEvo 4 Competition.nlogo
+/Curricular Models/GenEvo/GenEvo 1 Genetic Switch.png
+/Curricular Models/GenEvo/GenEvo 2 Genetic Drift.png
+/Curricular Models/GenEvo/GenEvo 3 Genetic Drift and Natural Selection.png
+/Curricular Models/GenEvo/GenEvo 4 Competition.png
 /Curricular Models/ProbLab/9-Blocks.nlogo
 /Curricular Models/ProbLab/Central Limit Theorem.nlogo
 /Curricular Models/ProbLab/Dice Stalagmite.nlogo

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,10 @@ target/
 /Curricular Models/BEAGLE Evolution/HubNet Activities/Bug Hunters Camouflage HubNet.nlogo
 /Curricular Models/BEAGLE Evolution/Mimicry.nlogo
 /Curricular Models/BEAGLE Evolution/Wolf Sheep Predation.nlogo
+/Curricular Models/GenEvo/GenEvo 1 Genetic Switch.nlogo
+/Curricular Models/GenEvo/GenEvo 2 Genetic Drift.nlogo
+/Curricular Models/GenEvo/GenEvo 3 Genetic Drift and Natural Selection.nlogo
+/Curricular Models/GenEvo/GenEvo 4 Competition.nlogo
 /Curricular Models/ProbLab/9-Blocks.nlogo
 /Curricular Models/ProbLab/Central Limit Theorem.nlogo
 /Curricular Models/ProbLab/Dice Stalagmite.nlogo

--- a/Curricular Models/GenEvo/GenEvo 1 Genetic Switch.nlogo
+++ b/Curricular Models/GenEvo/GenEvo 1 Genetic Switch.nlogo
@@ -1,0 +1,1217 @@
+globals [
+  ; Simulation constants
+  cell-width                 ; the width of the cell
+  cell-height                ; the height of the cell
+  cell-color                 ; the color of the cell
+  cell-wall                  ; a patch set that contains the patches on the cell wall
+  cell-patches               ; a patch set that contains the patches inside the cell
+  promoter                   ; a patch set that contains the patches that represent the promoter
+  operator                   ; a patch set that contains the patches that represent the operator
+  terminator                 ; a patch set that contains the patches that represent the terminator
+  lacZ-production-num        ; number of lacZ proteins produced per transcription event
+  lacZ-production-cost       ; cost incurred by the cell to produce one molecule of lacZ protein
+  lacY-production-num        ; number of lacZ proteins produced per transcription event
+  lacY-production-cost       ; cost incurred by the cell to produce one molecule of lacZ protein
+  initial-energy             ; initial energy of the cell
+  lactose-upper-limit        ; a variable to set the lactose quantity in the external environment
+
+  ; Global (cellular) properties
+  energy                     ; keeps track of the energy of the cell
+  division-number            ; a counter to keep track of number of cell division events
+  inhibited?                 ; boolean for whether or not the operator is inhibited
+]
+
+breed [ lacIs lacI ]         ; the lacI repressor protein (purple proteins)
+breed [ lacZs lacZ ]         ; the lacZ beta-galactosidase enzyme (light red proteins)
+breed [ lacYs lacY ]         ; the lacY lactose permease enzyme (light red rectangles)
+breed [ RNAPs RNAP ]         ; RNA Polymerase (brown proteins) that binds to the DNA and synthesizes mRNA
+breed [ lactoses lactose ]   ; lactose molecules (grey)
+
+lacIs-own [
+  partner                ; if it's a lacI complex, then partner is a lactose molecule
+  bound-to-operator?     ; a boolean to track if a lacI is bound to DNA as an inhibitor of transcription
+]
+
+RNAPs-own [
+  on-DNA?     ; a boolean to track if a RNAP is transcribing the DNA
+]
+
+lactoses-own [
+  partner     ; a partner is a lacI molecule with which an ONPG forms a complex
+  inside?     ; a boolean to track if a lactose molecule is inside the cell
+]
+
+to setup
+  clear-all
+
+  ; Set all of our constant global variables
+  set cell-width 44
+  set cell-height 16
+  set initial-energy 1000
+  set lactose-upper-limit 1500
+  set lacZ-production-num 5
+  set lacZ-production-cost 10
+  set lacY-production-num 5
+  set lacY-production-cost 10
+
+  ; Initialize all of our global property variables
+  set energy initial-energy
+  set division-number 0
+  set inhibited? false
+
+  draw-cell
+
+  ; add the necessary proteins to the cell
+  create-lacIs lacI-number [
+    set bound-to-operator? false
+    set partner nobody
+    set-shape
+    gen-xy-inside-inside
+  ]
+  create-RNAPs RNAP-number [
+    set on-DNA? false
+    set-shape
+    gen-xy-inside-inside
+  ]
+
+  if not LevelSpace? [
+    if lactose? [ update-lactose lactose-upper-limit ] ; add lactose if ON
+  ]
+  reset-ticks
+end
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;  Runtime Procedures ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+to go
+  go-lacI
+  go-lacY
+  go-lacZ
+  go-lactose
+  go-RNAP
+
+  ; if glucose? is ON, we get a steady stream of energy
+  if glucose? [ set energy energy + 10 ]
+  ; but it takes energy to maintain all of the proteins so consume some energy
+  set energy (energy - (count RNAPs + count lacIs + count lacZs) / 100 )
+
+  ; If we're in LevelSpace, then let the population model control division and lactose distribution.
+  if not LevelSpace? [
+    if lactose? [ update-lactose lactose-upper-limit ]
+
+    ; if we've doubled our energy, then divide
+    if (energy > 2 * initial-energy) [ divide-cell ]
+
+    ; if we're out of energy, die
+    if (energy < 0) [ user-message "The cell has run out of energy. It's dead!" stop ]
+  ]
+  tick
+end
+
+; controls the random movement of all turtles. If you're headed towards the cell wall, just turn until you're not
+to move ; turtle procedure
+  rt random-float 360
+  while [ (member? patch-ahead 1 cell-wall) or (member? patch-ahead 2 cell-wall) ] [ rt random-float 360 ]
+  forward 1
+end
+
+; procedure for movement and molecular interactions of lacI proteins
+to go-lacI
+  ; a lacI bound with the operator might dissociate from the operator
+  ask lacIs with [ bound-to-operator? ] [
+    if (random-float 1 < lacI-bond-leakage) [
+      dissociate-from-operator
+    ]
+  ]
+
+  ; lacIs with partners might dissociate from their partners
+  ask lacIs with [ partner != nobody ] [
+     if (random-float 1 < lacI-lactose-separation-chance) [
+      ask partner [
+        set partner nobody
+        move-to myself
+        set-shape
+        forward 1
+      ]
+      set partner nobody
+      forward -1
+    ]
+  ]
+
+  ; lacIs without partners either bind with the operator
+  ask lacIs with [ partner = nobody ] [
+    ifelse (not inhibited?) and ((member? patch-here operator) or (member? patch-ahead 1 operator)) [
+      set bound-to-operator? true
+      set inhibited? true
+      set heading 0
+      setxy -12 1
+    ] [ ; or maybe bind with a lactose
+      if (count lactoses-here with [ partner = nobody ] > 0  and (random-float 1 < lacI-lactose-binding-chance)) [
+        set partner one-of lactoses-here with [ partner = nobody ]
+        set-shape
+        ask partner [
+          set partner myself
+          set-shape
+        ]
+        dissociate-from-operator ; if necessary, dissociate from the operator
+      ]
+    ]
+  ]
+
+  ask lacIs with [ not bound-to-operator? ] [ move ]
+end
+
+; procedure for lacIs to dissociate from the operator
+to dissociate-from-operator ; lacI procedure
+  if (bound-to-operator?) [
+    set bound-to-operator? false
+    set inhibited? false
+    forward 3
+  ]
+end
+
+; procedure for movement and interactions of lacY proteins
+to go-lacY
+  ask lacYs [
+    ; if lacY hits the cellwall, it gets installed on the cell wall
+    ifelse (member? patch-ahead 2 cell-wall) [
+      ask patch-ahead 2 [ set pcolor (red + 2) ]
+      die
+    ]
+    ; otherwise we just move normally
+    [ move ]
+  ]
+  ; each tick, the installed lacYs have a chance of degrading
+  ask patches with [pcolor = (red + 2)] [
+    if (random-float 1 < lacY-degradation-chance) [ set pcolor cell-color ]
+  ]
+end
+
+; procedure for movement and interactions of lacZ proteins
+to go-lacZ
+  ; lacZs near lactose can digest that lactose and produce energy
+  ask lacZs with [ any? lactoses in-radius 1 with [ partner = nobody ] ] [
+    ask lactoses in-radius 1 with [ partner = nobody ] [
+      set energy energy + 10
+      die
+    ]
+  ]
+  ask lacZs [
+    move
+    if (random-float 1 < lacZ-degradation-chance) [ die ] ; there's a chance lacZ degrades
+  ]
+end
+
+; procedure for movement and interactions of lactose molecules
+to go-lactose
+  ; any lactoses near an installed lacY get pumped into the cell
+  ask lactoses with [ ([ pcolor ] of patch-ahead 2 = (red + 2)) and not inside? ] [
+    move-to patch-ahead 2 set heading towards patch 0 0 ; make sure the lactose gets inside the cell
+    fd 3
+    set inside? true
+  ]
+
+  ask lactoses [ move ]
+end
+
+
+; procedure for movement and molecular interactions of RNAPs
+to go-RNAP
+  ; In the presence of glucose, the probability of trancription is less.
+  let transcription-probability ifelse-value (glucose?) [ 0.1 ] [ 1 ]
+
+  ; If any RNAPs are close to the promoter and the operator is not inhibited
+  if (not inhibited?) [
+    ask RNAPs with [ (member? patch-here promoter) or (member? patch-ahead 1 promoter) or (member? patch-ahead 2 promoter) ] [
+      if random-float 1 < transcription-probability [
+         ; then start moving along the DNA to model transcription
+         setxy xcor 1
+         set heading 90
+         set on-dna? true
+      ]
+    ]
+  ]
+
+  ; If any RNAPs are in the process of transcribing (on-dna?) move them along
+  ask RNAPs with [ on-dna? ] [
+    forward 1
+    ; when you reach the terminator, synthesize the proteins
+    if (member? patch-here terminator) [
+      synthesize-proteins
+      set on-dna? false
+      gen-xy-inside-inside
+    ]
+  ]
+
+  ; Any other RNAPs just move around the cell
+  ask RNAPs with [ not on-dna? ] [
+    move
+    ; Because our DNA is fixed within the cell,  RNAPs at both ends of the
+    ; of the cell are moved to a random position inside the cell
+    if (xcor > (cell-width - 3) or xcor < (- cell-width + 3)) [ gen-xy-inside-inside ]
+  ]
+end
+
+; procedure to synthesize proteins upon dna transcription
+to synthesize-proteins
+  hatch-lacYs lacY-production-num [
+    gen-xy-inside-inside
+    set-shape
+  ]
+  hatch-lacZs lacZ-production-num [
+    gen-xy-inside-inside
+    set-shape
+  ]
+  set energy energy - (lacY-production-cost * lacY-production-num) - (lacZ-production-cost * lacZ-production-num)
+end
+
+; procedure to simulate cell division; each type of turtle (except RNAPs and lacIs) population is halved
+to divide-cell
+  ask n-of (count lacIs with [ partner != nobody ] / 2) lacIs with [ partner != nobody ] [
+    ask partner [ die ]
+    set partner nobody
+    set-shape
+  ]
+  ask n-of (count lactoses with [ inside? and partner = nobody ] / 2) lactoses with [ inside? and partner = nobody ] [ die ]
+  ask n-of (count lacYs / 2) lacYs [ die ]
+  ask n-of (count patches with [ pcolor = (red + 2) ] / 2) patches with [ pcolor = (red + 2) ] [ set pcolor cell-color ]
+  ask n-of (count lacZs / 2) lacZs [ die ]
+
+  set energy energy / 2
+  set division-number division-number + 1
+end
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;  Helper Procedures ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; procedure that sets patches for the cell, the cell-wall, and the
+; regions of the DNA; although it looks complicated, really we're just
+; addressing a bunch of patch-sets
+to draw-cell
+  set cell-wall ( patch-set
+    ; the vertical part of the cell wall
+    (patches with [
+      (pycor = cell-height or pycor = (- cell-height))
+       and
+      (pxcor > (-(cell-width + 1)) and pxcor < (cell-width + 1))
+    ])
+    ; the horizontal part of the cell wall
+    (patches with [
+       (pxcor = cell-width or pxcor = (- cell-width))
+        and
+       (pycor > (-(cell-height + 1)) and pycor < (cell-height + 1))
+     ])
+  )
+  set-cell-color brown
+
+  ; patches inside the cell-wall are set white.
+  set cell-patches patches with [
+    (pycor > (- cell-height) and pycor < cell-height)
+     and
+    (pxcor > (- cell-width)  and pxcor < cell-width)
+  ]
+  ask cell-patches [ set pcolor white ]
+
+  ; the operon patches are blue
+  let operon patches with [ (pycor > -1 and pycor < 2) and (pxcor > -10 and pxcor < 17) ]
+  ask operon [ set pcolor blue ]
+
+  ; promoter is green
+  set promoter patches with [ (pycor > -1 and pycor < 2) and (pxcor > -22 and pxcor < -14) ]
+  ask promoter [ set pcolor green ]
+
+  ; operator is orange
+  set operator patches with [
+   ((pycor = 0) and (pxcor > -15 and pxcor < -9))
+    or
+   (( pycor = 1) and (( pxcor = -10) or ( pxcor = -12) or ( pxcor = -14)))
+  ]
+  ask operator [ set pcolor orange ]
+
+  ; the terminator patches are gray
+  set terminator patches with [
+    ((pycor > -1) and (pycor < 2))
+     and
+    ((pxcor > 16 and pxcor < 19))
+  ]
+  ask terminator [ set pcolor gray ]
+end
+
+; procedure that assigns a specific shape to an agent based on breed
+to set-shape ; turtle procedure
+  if breed = lacIs [
+    set size 6
+    ifelse partner = nobody [
+      set shape "lacI"
+    ][ ; if you have a partner, you're a lacI-lactose-complex
+      set shape "lacI-lactose-complex"
+      set size 6
+    ]
+  ]
+  if breed = RNAPs [
+    set size 5
+    set shape "RNAP"
+    set color brown
+  ]
+  if breed = lactoses [
+    ifelse partner = nobody [
+      set size 2
+      set shape "pentagon"
+      set hidden? false
+    ][ ; if you have a partner, you're invisible!
+      set hidden? true
+     ]
+  ]
+  if breed = lacYs [
+    set shape "pump"
+    set color (red + 2)
+    set size 3
+  ]
+  if breed = lacZs [
+    set shape "protein"
+    set color (red + 2)
+    set size 4
+  ]
+end
+
+; to keep the lactose amount constant if the lactose? switch is on
+to update-lactose [ upper-limit ]
+    let num-lactose-outside count lactoses with [ not inside? ]
+    ifelse num-lactose-outside > upper-limit [
+      ask n-of (num-lactose-outside - upper-limit) lactoses with [ not inside? ] [ die ]
+    ][
+      create-lactoses (upper-limit - num-lactose-outside) [
+        gen-xy-inside-outside
+        set inside? false
+        set partner nobody
+        set-shape
+      ]
+    ]
+end
+
+; procedure to place a molecule inside the cell
+to gen-xy-inside-inside ; turtle procedure
+  setxy random-xcor random-ycor
+  while [ not member? patch-here cell-patches] [
+    setxy random-xcor random-ycor
+  ]
+end
+
+; procedure to place a molecule outside the cell
+to gen-xy-inside-outside ; turtle procedure
+  setxy random-xcor random-ycor
+  while [(member? patch-here cell-wall) or (member? patch-here cell-patches)] [
+    setxy random-xcor random-ycor
+  ]
+end
+
+; procedure to set the color of the cell wall. (this is a separate procedure because
+; in LevelSpace, the cell wall color needs to be assigned)
+to set-cell-color [ the-color ]
+  set cell-color the-color
+  ask cell-wall [ set pcolor the-color ]
+end
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;  LevelSpace Procedures ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; procedure to setup the cell according to parameters passed in from the population model
+to set-initial-variables [ the-list ]
+
+  ; 'the-list' is the following list of numbers (or counts) and booleans
+  ; [ cell-color initial-energy energy initial-lacYs initial-lacYs-inserted initial-lacZs
+  ;    initial-lacI-lactose-complexes initial-lactose-inside initial-lactose-outside
+  ;    glucose?-setting lactose?-setting ]
+
+  ; we use NetLogo's `item` primitive to directly select elements of the list
+  set LevelSpace?      true
+  set-cell-color       item 0 the-list
+  set initial-energy   item 1 the-list
+  set energy           initial-energy
+  set lactose?         item 8 the-list
+  set glucose?         item 9 the-list
+
+  ; create the necessary turtles
+  ask n-of (item 3 the-list) cell-wall [ set pcolor red + 2 ]
+  create-lacYs (item 2 the-list) [ gen-xy-inside-inside ]
+  create-lacZs (item 4 the-list) [ gen-xy-inside-inside ]
+  create-lactoses (item 6 the-list) [
+    set inside? true
+    set partner nobody
+    gen-xy-inside-inside
+  ]
+  ask n-of (item 5 the-list) lacIs [
+    hatch-lactoses 1 [
+      set inside? true
+      set partner myself
+      ask partner [ set partner myself ]
+    ]
+  ]
+  ask turtles [ set-shape ]
+end
+
+; procedure to extract list of variables to use in the population model when using LevelSpace
+to-report send-variables-list
+  report (list (energy) (count lacYs) (count (patches with [pcolor = red + 2])) (count lacZs)
+      (count (lacIs with [ partner != nobody ])) (count (lactoses with [ (inside?) and (partner = nobody) ])) (count (lactoses with [ not inside? ])))
+end
+
+
+; Copyright 2016 Uri Wilensky.
+; See Info tab for full copyright and license.
+@#$#@#$#@
+GRAPHICS-WINDOW
+330
+10
+943
+354
+-1
+-1
+5.0
+1
+12
+1
+1
+1
+0
+1
+1
+1
+-60
+60
+-33
+33
+1
+1
+1
+ticks
+30.0
+
+BUTTON
+10
+10
+90
+80
+NIL
+setup
+NIL
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+1
+
+BUTTON
+95
+10
+175
+80
+NIL
+go
+T
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+0
+
+SLIDER
+10
+360
+325
+393
+lacI-bond-leakage
+lacI-bond-leakage
+0
+0.1
+0.1
+0.0001
+1
+NIL
+HORIZONTAL
+
+SLIDER
+10
+400
+325
+433
+lacI-lactose-binding-chance
+lacI-lactose-binding-chance
+0.99990
+1
+0.9999
+0.00001
+1
+NIL
+HORIZONTAL
+
+SLIDER
+10
+480
+325
+513
+lacY-degradation-chance
+lacY-degradation-chance
+0
+0.01
+2.0E-4
+0.0001
+1
+NIL
+HORIZONTAL
+
+SLIDER
+10
+320
+165
+353
+lacI-number
+lacI-number
+1
+50
+15.0
+1
+1
+NIL
+HORIZONTAL
+
+SLIDER
+170
+320
+325
+353
+RNAP-number
+RNAP-number
+0
+50
+15.0
+1
+1
+NIL
+HORIZONTAL
+
+SLIDER
+10
+440
+325
+473
+lacI-lactose-separation-chance
+lacI-lactose-separation-chance
+0
+0.01
+0.00377
+0.00001
+1
+NIL
+HORIZONTAL
+
+SLIDER
+10
+520
+325
+553
+lacZ-degradation-chance
+lacZ-degradation-chance
+0
+0.01
+1.0E-4
+0.0001
+1
+NIL
+HORIZONTAL
+
+SWITCH
+180
+10
+325
+43
+lactose?
+lactose?
+0
+1
+-1000
+
+PLOT
+640
+360
+945
+555
+Average Cell Division Time
+Time
+Number of Ticks
+0.0
+10.0
+0.0
+10.0
+true
+false
+"" ""
+PENS
+"default" 1.0 0 -16777216 true "" "if division-number > 0 [ plotxy ticks (ticks / division-number) ]"
+
+SWITCH
+180
+45
+325
+78
+glucose?
+glucose?
+1
+1
+-1000
+
+MONITOR
+810
+385
+932
+430
+Cell Division Time
+ifelse-value (division-number > 0) [\n  precision (ticks / division-number) 0\n][\n \"n/a\"\n]
+17
+1
+11
+
+PLOT
+330
+360
+635
+555
+lacZ Number
+Time
+Frequency
+0.0
+10.0
+0.0
+10.0
+true
+false
+"" ""
+PENS
+"default" 1.0 0 -16777216 true "" "plot count lacZs"
+
+SWITCH
+50
+180
+190
+213
+LevelSpace?
+LevelSpace?
+1
+1
+-1000
+
+PLOT
+10
+85
+325
+315
+Energy
+NIL
+NIL
+0.0
+10.0
+0.0
+1000.0
+true
+false
+"" ""
+PENS
+"default" 1.0 0 -16777216 true "" "plot energy"
+
+@#$#@#$#@
+## WHAT IS IT?
+
+This model simulates a complex phenomenon in molecular biology: the “switching” (on and off) of genes. Through specific regulatory proteins and specific DNA sequences, each regulated gene has the ability to turn on or off in response to environmental stimuli.
+
+Specifically, it is a model of the [lac-operon](https://en.wikipedia.org/wiki/Lac_operon) of a bacterium (E. coli.), which is responsible for the uptake and digestion of lactose through the synthesis of the enzymes [permease (lacY)](https://en.wikipedia.org/wiki/Lactose_permease) and [beta-galactosidase (lacZ)](https://en.wikipedia.org/wiki/Beta-galactosidase).
+
+## HOW IT WORKS
+
+While the genetic switch is in essence, a positive feedback loop, it is responsible for regulating the synthesis of proteins required to conduct the uptake and digestion of lactose.
+
+In this model, there are in fact two sugars: glucose and lactose. Glucose is "preferred" as an energy source over lactose. When there is glucose and/or no lactose in the surrounding environment, the genetic switch is at an _off steady-state_. This is because the repressor protein [lacI](https://en.wikipedia.org/wiki/Lac_repressor) prevents (mostly) the bacteria from producing the proteins, by binding to the <a href="https://en.wikipedia.org/wiki/Operator_(biology)">operator site</a> of the DNA. In this steady state, relatively little permease (lacY) and beta-galactosidase (lacZ) are produced.
+
+When lactose is introduced to the outside environment, the lactose molecules enter into the bacterium through permeases (lacYs) that get inserted into the cell-wall. Some lactose molecules that enter the cell bind to lacIs, preventing them from binding to the operator site of the DNA. This, in turn, causes more lacYs to be produced which causes more lactose to enter the cell, thus creating a positive feedback loop. The lacZs, meanwhile digest free roaming lactoses inside the cell for energy.
+
+The effect of glucose (through [cAMP](https://en.wikipedia.org/wiki/Cyclic_adenosine_monophosphate)) is only implicitly modelled by changing affecting the amount of lacZ and lacI produced.
+
+### Important Proteins
+1. *RNAP* – These are RNA polymerases that synthesize mRNA from DNA. These are represented by brown blobs in the model. This model does not include mRNAs.
+2. *lacI* – The purple-colored shapes in the model represent a repressor (lacI proteins). They bind to the operator region (see below) of the DNA and do not let RNAP to pass along the gene, thus stopping protein synthesis. When lactose binds to lacI, they form lacI-lactose complexes (shown by a purple shape with a grey dot attached to it). These complexes cannot bind to the operator region of the DNA.
+3. *lacY* – These are shown in the model as light red rectangles. They are produced when an RNAP passes along the gene. When they hit the cell-wall, they get installed on the cell-wall (shown by light patches). Lactose (grey pentagons) from the outside environment is transported inside the cell through these light red patches.
+4. *lacZ* – These are shown as light red colored proteins. They are present inside the cell. When they collide with a lactose molecule, the lactose molecule is digested and energy is produced.
+
+### DNA Regions
+There are four important DNA regions in this model:
+
+1. *Promoter* – This region is indicated by the color green. As an RNAP binds to the promoter region and if the operator is free, it moves along DNA to start transcription.
+2. *Operator* – This region is indicated by the color orange. The lacI repressor protein binds to this region and prevents RNAP from moving along the DNA.
+3. *Operon* – This is indicated by the color blue. This is where the genetic material necessary to create lacY and lacZ is found.
+4. *Terminator* – This is indicated by the color grey. RNAP separates from the DNA when it reaches this region.
+
+As RNAP moves along the gene, lacY and lacZ molecules are produced (five molecules per transcription). We do not show translation by ribosomes in this model.
+
+### Energy of the cell
+Producing and maintaining the protein machinery for a cell takes energy. So as a cell produces proteins and maintains those proteins (RNAPs, lacIs and lacZs), its energy decreases.
+
+Energy of the cell increases when lactose inside the cell is digested.
+
+### Cell division
+When the energy of the cell doubles from its initial value, it splits into two daughter cells. Each of these cells has half of the energy of the original cell as well as half the number of each type of protein in the original cell.
+
+## HOW TO USE IT
+
+### To setup
+
+Each slider controls a certain aspect of this genetic regulation circuit. Refer to the Sliders Section for more information on the function of each variable.
+
+Once all the sliders are set to the desired levels, the user should click SETUP to initialize the cell.
+
+### To run
+
+To observe the switching behavior of the genetic switch, set GLUCOSE? to ON and LACTOSE? to OFF. Let the simulation run for a few hundred ticks. Observe the changes in the energy of the cell as time progresses and cell divides. The energy drops to half when a cell divides.
+
+To run the simulation faster, uncheck the 'view updates' box for several thousand ticks. Observe the lacZ production in the graph. It varies because of the stochastic nature of the molecular interactions in the cell. This variability even when the switch "is off" is why genetic switches are referred to as "leaky".
+
+Set GLUCOSE? to OFF and LACTOSE? to ON to see the behavior of the genetic switch by observing change in the lacZ production.
+
+While molecular interactions (micro) are best observed through running the simulation with 'view updates' checked, to observe cellular behavior (macro), 'view updates' should be unchecked and the simulation should be run for several thousand ticks.
+
+### Buttons
+
+The SETUP button initializes the model
+
+The GO button runs the simulation until the cell dies
+
+### Switches
+
+LACTOSE?  - If ON, lactose is added to the external medium (outside of the cell)
+
+GLUCOSE?  - If ON, glucose is added to the external medium. Glucose is implicitly modelled meaning that when GLUCOSE? is ON, energy of a cell increases at a constant rate (10 units/tick). In addition, since glucose is a "preferred energy source", the lac promoter is less active when GLUCOSE? is ON.
+
+### Sliders
+
+LACI-NUMBER - Sets the number of lacIs
+
+RNAP-NUMBER - Sets the number of RNAPs
+
+LACI-BOND-LEAKAGE - This is the chance a lacI molecule bonded to the operator detaches from the operator
+
+LACI-LACTOSE-BINDING-CHANCE - Sets the chance that a lactose and a lacI come together to form a lacI-lactose complex
+
+LACI-LACTOSE-SEPARATION-CHANCE - Sets the chance that a lacI-lactose complex separates
+
+LACY-DEGRADATION-CHANCE - Sets the chance of degradation of a lacY that is installed on the cell-wall
+
+LACZ-DEGRADATION-CHANCE - Sets the chance of degradation of a lacZ molecules in the cell
+
+### Plots
+
+Energy – Plots the amount of energy in the cell over time
+
+lacZ Number – Plots the number of lacZ molecules inside a cell
+
+Average Cell Division Time – Plots the average number of ticks between two cell division events. It can be used as a growth rate indicator.
+
+## THINGS TO NOTICE
+
+Notice the three parts of the molecular mechanism involved in the control of the genetic switch:
+1. Uptake of lactose from outside to inside through lacY
+2. Repression by lacI in absence of lactose
+3. Formation of lacI-lactose complex in presence of lactose and removal of repression
+
+Notice the changes in energy of the cells when lactose is added (that is, when LACTOSE? is ON and when LACTOSE? is OFF).
+
+Notice the energy changes when a cell divides.
+
+Notice the changes in the Average Cell Division Time as time progresses.
+
+Notice the effect of changes in the environmental conditions (ON/OFF of GLUCOSE? and LACTOSE? on the Average Cell Division Time and the lacZ Number.
+
+## THINGS TO TRY
+
+Try to make the genetic switch more sensitive to the environmental conditions. It should be "on" only when lactose is present and "off" otherwise. You can do this be changing the slider parameters.
+
+If the cell starts to uptake lactose and produce energy faster, does the Average Cell Division Time also decrease?
+
+## EXTENDING THE MODEL
+
+In real life, cells aren't flat! See if you can extend the model into three-dimensions with NetLogo 3D.
+
+## NETLOGO FEATURES
+
+This model uses NetLogo's `with` primitive extensively. This is because, although the different proteins are represented by different `breeds`, the proteins also exist in various states.
+
+## RELATED MODELS
+
+* GenDrift Sample Models
+* GenEvo Curricular Models
+
+## HOW TO CITE
+
+If you mention this model or the NetLogo software in a publication, we ask that you include the citations below.
+
+For the model itself:
+
+* Dabholkar, S., Bain, C. and Wilensky, U. (2016).  NetLogo GenEvo 1 Genetic Switch model.  http://ccl.northwestern.edu/netlogo/models/GenEvo1GeneticSwitch.  Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+
+Please cite the NetLogo software as:
+
+* Wilensky, U. (1999). NetLogo. http://ccl.northwestern.edu/netlogo/. Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+
+To cite the GenEvo Systems Biology curriculum as a whole, please use:
+
+* Dabholkar, S. & Wilensky, U. (2016). GenEvo Systems Biology curriculum. http://ccl.northwestern.edu/curriculum/genevo/. Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+
+## COPYRIGHT AND LICENSE
+
+Copyright 2016 Uri Wilensky.
+
+![CC BY-NC-SA 3.0](http://ccl.northwestern.edu/images/creativecommons/byncsa.png)
+
+This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 License.  To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/3.0/ or send a letter to Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+
+Commercial licenses are also available. To inquire about commercial licenses, please contact Uri Wilensky at uri@northwestern.edu.
+
+<!-- 2016 GenEvo Cite: Dabholkar, S., Bain, C. -->
+@#$#@#$#@
+default
+true
+0
+Polygon -7500403 true true 150 5 40 250 150 205 260 250
+
+airplane
+true
+0
+Polygon -7500403 true true 150 0 135 15 120 60 120 105 15 165 15 195 120 180 135 240 105 270 120 285 150 270 180 285 210 270 165 240 180 180 285 195 285 165 180 105 180 60 165 15
+
+arrow
+true
+0
+Polygon -7500403 true true 150 0 0 150 105 150 105 293 195 293 195 150 300 150
+
+box
+false
+0
+Polygon -7500403 true true 150 285 285 225 285 75 150 135
+Polygon -7500403 true true 150 135 15 75 150 15 285 75
+Polygon -7500403 true true 15 75 15 225 150 285 150 135
+Line -16777216 false 150 285 150 135
+Line -16777216 false 150 135 15 75
+Line -16777216 false 150 135 285 75
+
+bug
+true
+0
+Circle -7500403 true true 96 182 108
+Circle -7500403 true true 110 127 80
+Circle -7500403 true true 110 75 80
+Line -7500403 true 150 100 80 30
+Line -7500403 true 150 100 220 30
+
+butterfly
+true
+0
+Polygon -7500403 true true 150 165 209 199 225 225 225 255 195 270 165 255 150 240
+Polygon -7500403 true true 150 165 89 198 75 225 75 255 105 270 135 255 150 240
+Polygon -7500403 true true 139 148 100 105 55 90 25 90 10 105 10 135 25 180 40 195 85 194 139 163
+Polygon -7500403 true true 162 150 200 105 245 90 275 90 290 105 290 135 275 180 260 195 215 195 162 165
+Polygon -16777216 true false 150 255 135 225 120 150 135 120 150 105 165 120 180 150 165 225
+Circle -16777216 true false 135 90 30
+Line -16777216 false 150 105 195 60
+Line -16777216 false 150 105 105 60
+
+car
+true
+0
+Polygon -7500403 true true 180 15 164 21 144 39 135 60 132 74 106 87 84 97 63 115 50 141 50 165 60 225 150 285 165 285 225 285 225 15 180 15
+Circle -16777216 true false 180 30 90
+Circle -16777216 true false 180 180 90
+Polygon -16777216 true false 80 138 78 168 135 166 135 91 105 106 96 111 89 120
+Circle -7500403 true true 195 195 58
+Circle -7500403 true true 195 47 58
+
+circle
+false
+0
+Circle -7500403 true true 0 0 300
+
+circle 2
+false
+0
+Circle -7500403 true true 0 0 300
+Circle -16777216 true false 30 30 240
+
+cow
+false
+0
+Polygon -7500403 true true 200 193 197 249 179 249 177 196 166 187 140 189 93 191 78 179 72 211 49 209 48 181 37 149 25 120 25 89 45 72 103 84 179 75 198 76 252 64 272 81 293 103 285 121 255 121 242 118 224 167
+Polygon -7500403 true true 73 210 86 251 62 249 48 208
+Polygon -7500403 true true 25 114 16 195 9 204 23 213 25 200 39 123
+
+cylinder
+false
+0
+Circle -7500403 true true 0 0 300
+
+dot
+false
+0
+Circle -7500403 true true 90 90 120
+
+face happy
+false
+0
+Circle -7500403 true true 8 8 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Polygon -16777216 true false 150 255 90 239 62 213 47 191 67 179 90 203 109 218 150 225 192 218 210 203 227 181 251 194 236 217 212 240
+
+face neutral
+false
+0
+Circle -7500403 true true 8 7 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Rectangle -16777216 true false 60 195 240 225
+
+face sad
+false
+0
+Circle -7500403 true true 8 8 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Polygon -16777216 true false 150 168 90 184 62 210 47 232 67 244 90 220 109 205 150 198 192 205 210 220 227 242 251 229 236 206 212 183
+
+fish
+false
+0
+Polygon -1 true false 44 131 21 87 15 86 0 120 15 150 0 180 13 214 20 212 45 166
+Polygon -1 true false 135 195 119 235 95 218 76 210 46 204 60 165
+Polygon -1 true false 75 45 83 77 71 103 86 114 166 78 135 60
+Polygon -7500403 true true 30 136 151 77 226 81 280 119 292 146 292 160 287 170 270 195 195 210 151 212 30 166
+Circle -16777216 true false 215 106 30
+
+flag
+false
+0
+Rectangle -7500403 true true 60 15 75 300
+Polygon -7500403 true true 90 150 270 90 90 30
+Line -7500403 true 75 135 90 135
+Line -7500403 true 75 45 90 45
+
+flower
+false
+0
+Polygon -10899396 true false 135 120 165 165 180 210 180 240 150 300 165 300 195 240 195 195 165 135
+Circle -7500403 true true 85 132 38
+Circle -7500403 true true 130 147 38
+Circle -7500403 true true 192 85 38
+Circle -7500403 true true 85 40 38
+Circle -7500403 true true 177 40 38
+Circle -7500403 true true 177 132 38
+Circle -7500403 true true 70 85 38
+Circle -7500403 true true 130 25 38
+Circle -7500403 true true 96 51 108
+Circle -16777216 true false 113 68 74
+Polygon -10899396 true false 189 233 219 188 249 173 279 188 234 218
+Polygon -10899396 true false 180 255 150 210 105 210 75 240 135 240
+
+hello
+true
+0
+
+house
+false
+0
+Rectangle -7500403 true true 45 120 255 285
+Rectangle -16777216 true false 120 210 180 285
+Polygon -7500403 true true 15 120 150 15 285 120
+Line -16777216 false 30 120 270 120
+
+laci
+true
+0
+Polygon -8630108 true false 120 120 135 135 150 135 165 120 270 120 270 180 210 180 210 210 165 210 165 180 120 180 120 210 75 210 75 180 15 180 15 120 120 120
+
+laci-lactose-complex
+true
+9
+Polygon -8630108 true false 15 135 15 210 150 210 270 210 270 135 165 135 150 150 135 150 120 135 75 135
+Polygon -7500403 true false 135 150 150 150 165 135 150 120 135 120 120 135
+
+leaf
+false
+0
+Polygon -7500403 true true 150 210 135 195 120 210 60 210 30 195 60 180 60 165 15 135 30 120 15 105 40 104 45 90 60 90 90 105 105 120 120 120 105 60 120 60 135 30 150 15 165 30 180 60 195 60 180 120 195 120 210 105 240 90 255 90 263 104 285 105 270 120 285 135 240 165 240 180 270 195 240 210 180 210 165 195
+Polygon -7500403 true true 135 195 135 240 120 255 105 255 105 285 135 285 165 240 165 195
+
+line
+true
+0
+Line -7500403 true 150 0 150 300
+
+line half
+true
+0
+Line -7500403 true 150 0 150 150
+
+pentagon
+false
+15
+Polygon -7500403 true false 150 90 90 135 120 195 180 195 210 135
+
+person
+false
+0
+Circle -7500403 true true 110 5 80
+Polygon -7500403 true true 105 90 120 195 90 285 105 300 135 300 150 225 165 300 195 300 210 285 180 195 195 90
+Rectangle -7500403 true true 127 79 172 94
+Polygon -7500403 true true 195 90 240 150 225 180 165 105
+Polygon -7500403 true true 105 90 60 150 75 180 135 105
+
+plant
+false
+0
+Rectangle -7500403 true true 135 90 165 300
+Polygon -7500403 true true 135 255 90 210 45 195 75 255 135 285
+Polygon -7500403 true true 165 255 210 210 255 195 225 255 165 285
+Polygon -7500403 true true 135 180 90 135 45 120 75 180 135 210
+Polygon -7500403 true true 165 180 165 210 225 180 255 120 210 135
+Polygon -7500403 true true 135 105 90 60 45 45 75 105 135 135
+Polygon -7500403 true true 165 105 165 135 225 105 255 45 210 60
+Polygon -7500403 true true 135 90 120 45 150 15 180 45 165 90
+
+protein
+true
+0
+Polygon -7500403 false true 165 75 135 75 135 90 165 105 165 75 165 60 135 105 165 120 180 120 180 90 150 75 150 105 180 135 165 135 165 120 180 120 195 135 195 105 195 105 165 105 150 105 165 90 180 75 165 75 150 90 165 105 150 120 135 150 120 150 120 165 150 165 180 165 165 135 165 135
+Polygon -7500403 false true 165 150 165 165 150 180 135 165 120 195 150 210 165 180 180 165 150 165 135 150 135 165 120 165 120 210 150 195 180 195 180 180 195 165 165 150 165 150 210 165 180 210 150 180 135 210 120 225 150 225
+Polygon -7500403 false true 135 120 120 120 150 135 150 150 180 150 150 120 120 135 135 105 105 105 180 135 210 150 105 120 105 135 210 195
+
+pump
+true
+0
+Rectangle -7500403 true true 105 60 195 240
+
+rnap
+true
+10
+Circle -13345367 true true 45 75 150
+Circle -13345367 true true 105 75 150
+
+square
+false
+0
+Rectangle -7500403 true true 30 30 270 270
+
+square 2
+false
+0
+Rectangle -7500403 true true 30 30 270 270
+Rectangle -16777216 true false 60 60 240 240
+
+star
+false
+0
+Polygon -7500403 true true 151 1 185 108 298 108 207 175 242 282 151 216 59 282 94 175 3 108 116 108
+
+target
+false
+0
+Circle -7500403 true true 0 0 300
+Circle -16777216 true false 30 30 240
+Circle -7500403 true true 60 60 180
+Circle -16777216 true false 90 90 120
+Circle -7500403 true true 120 120 60
+
+tree
+false
+0
+Circle -7500403 true true 118 3 94
+Rectangle -6459832 true false 120 195 180 300
+Circle -7500403 true true 65 21 108
+Circle -7500403 true true 116 41 127
+Circle -7500403 true true 45 90 120
+Circle -7500403 true true 104 74 152
+
+triangle
+false
+0
+Polygon -7500403 true true 150 30 15 255 285 255
+
+triangle 2
+false
+0
+Polygon -7500403 true true 150 30 15 255 285 255
+Polygon -16777216 true false 151 99 225 223 75 224
+
+truck
+false
+0
+Rectangle -7500403 true true 4 45 195 187
+Polygon -7500403 true true 296 193 296 150 259 134 244 104 208 104 207 194
+Rectangle -1 true false 195 60 195 105
+Polygon -16777216 true false 238 112 252 141 219 141 218 112
+Circle -16777216 true false 234 174 42
+Rectangle -7500403 true true 181 185 214 194
+Circle -16777216 true false 144 174 42
+Circle -16777216 true false 24 174 42
+Circle -7500403 false true 24 174 42
+Circle -7500403 false true 144 174 42
+Circle -7500403 false true 234 174 42
+
+turtle
+true
+0
+Polygon -10899396 true false 215 204 240 233 246 254 228 266 215 252 193 210
+Polygon -10899396 true false 195 90 225 75 245 75 260 89 269 108 261 124 240 105 225 105 210 105
+Polygon -10899396 true false 105 90 75 75 55 75 40 89 31 108 39 124 60 105 75 105 90 105
+Polygon -10899396 true false 132 85 134 64 107 51 108 17 150 2 192 18 192 52 169 65 172 87
+Polygon -10899396 true false 85 204 60 233 54 254 72 266 85 252 107 210
+Polygon -7500403 true true 119 75 179 75 209 101 224 135 220 225 175 261 128 261 81 224 74 135 88 99
+
+wheel
+false
+0
+Circle -7500403 true true 3 3 294
+Circle -16777216 true false 30 30 240
+Line -7500403 true 150 285 150 15
+Line -7500403 true 15 150 285 150
+Circle -7500403 true true 120 120 60
+Line -7500403 true 216 40 79 269
+Line -7500403 true 40 84 269 221
+Line -7500403 true 40 216 269 79
+Line -7500403 true 84 40 221 269
+
+x
+false
+0
+Polygon -7500403 true true 270 75 225 30 30 225 75 270
+Polygon -7500403 true true 30 75 75 30 270 225 225 270
+@#$#@#$#@
+NetLogo 6.0-M9
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+default
+0.0
+-0.2 0 0.0 1.0
+0.0 1 1.0 0.0
+0.2 0 0.0 1.0
+link direction
+true
+0
+Line -7500403 true 150 150 90 180
+Line -7500403 true 150 150 210 180
+@#$#@#$#@
+1
+@#$#@#$#@

--- a/Curricular Models/GenEvo/GenEvo 2 Genetic Drift.nlogo
+++ b/Curricular Models/GenEvo/GenEvo 2 Genetic Drift.nlogo
@@ -174,7 +174,7 @@ HORIZONTAL
 TEXTBOX
 20
 190
-346
+410
 232
 Each trait is represented by a different color in the model.
 11

--- a/Curricular Models/GenEvo/GenEvo 2 Genetic Drift.nlogo
+++ b/Curricular Models/GenEvo/GenEvo 2 Genetic Drift.nlogo
@@ -1,0 +1,589 @@
+breed [ ecolis ecoli ]
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;SETUP PROCEDURES ;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+to setup     ; Sets up the population of bacteria (E. coli) randomly across the world.
+  clear-all
+  let color-list [ gray red brown yellow green cyan violet magenta ]
+
+  create-ecolis number-of-traits [
+    set shape "ecoli"
+    setxy random-xcor random-ycor
+    set color first color-list
+    set color-list but-first color-list ; each type has a unique color so we remove this color form our list
+  ]
+
+  reset-ticks
+end
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;RUNTIME PROCEDURES ;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+to go
+  ask ecolis [
+    move
+    maybe-reproduce
+    maybe-die
+  ]
+  tick
+end
+
+to move   ; E. coli cells move randomly across the world.
+  rt random-float 360
+  fd 1
+end
+
+to maybe-reproduce  ; E. coli cells reproduce based on random chance. This random chance of reproduction is same for all the cells.
+  if random-float 100 > 99 [
+    hatch 1 [
+      rt random-float 360
+      fd 1
+    ]
+  ]
+end
+
+to maybe-die   ; random chance of death when the total population exceeds the carrying capacity
+  if random (count ecolis) > carrying-capacity [
+    die
+  ]
+end
+
+
+; Copyright 2016 Uri Wilensky.
+; See Info tab for full copyright and license.
+@#$#@#$#@
+GRAPHICS-WINDOW
+451
+15
+921
+486
+-1
+-1
+14.0
+1
+10
+1
+1
+1
+0
+0
+0
+1
+-16
+16
+-16
+16
+1
+1
+1
+ticks
+30.0
+
+BUTTON
+17
+13
+108
+71
+NIL
+setup
+NIL
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+1
+
+BUTTON
+124
+14
+212
+70
+NIL
+go
+T
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+0
+
+PLOT
+20
+220
+440
+499
+Population Dynamics Graph
+Time
+Frequency
+0.0
+10.0
+0.0
+10.0
+true
+true
+"" ""
+PENS
+"1" 1.0 0 -7500403 true "" "plot count ecolis with [ color = gray ]"
+"2" 1.0 0 -2674135 true "" "plot count ecolis with [ color = red ]"
+"3" 1.0 0 -6459832 true "" "plot count ecolis with [ color = brown ]"
+"4" 1.0 0 -1184463 true "" "plot count ecolis with [ color = yellow ]"
+"5" 1.0 0 -10899396 true "" "plot count ecolis with [ color = green ]"
+"6" 1.0 0 -11221820 true "" "plot count ecolis with [ color = cyan ]"
+"7" 1.0 0 -8630108 true "" "plot count ecolis with [ color = violet ]"
+"8" 1.0 0 -5825686 true "" "plot count ecolis with [ color = magenta ]"
+
+SLIDER
+19
+98
+191
+131
+carrying-capacity
+carrying-capacity
+0
+500
+50.0
+10
+1
+NIL
+HORIZONTAL
+
+SLIDER
+19
+143
+191
+176
+number-of-traits
+number-of-traits
+1
+8
+8.0
+1
+1
+NIL
+HORIZONTAL
+
+TEXTBOX
+20
+190
+346
+232
+Each trait is represented by a different color in the model.
+11
+0.0
+1
+
+@#$#@#$#@
+## WHAT IS IT?
+
+This model is an example of genetic drift in a population of asexually reproducing bacteria E. coli. It starts with several types of E. coli, each with a different trait (which we represent with unique colors). The model shows that competing types of E. coli, each reproducing with equal likelihood on each turn, will ultimately converge on one type without any selection pressure forcing this convergence.  The idea, explained in more detail in Dennett's _Darwin's Dangerous Idea_, is that trait drifts can occur without any particular purpose or 'selection pressure'.
+
+## HOW IT WORKS
+
+The model starts with different colored E. coli cells, randomly distributed across the world. Each turn, each E. coli moves randomly around the world and has a chance (equal for all types of E. coli) of reproducing to form to two daughter cells of its type (of the same color).
+
+If the total number of E. coli cells is greater than the carrying capacity, the maximum number of E. coli that is supported by the system, then E. coli cells are randomly killed until the number of E. coli is less than the carrying capacity.
+
+By statistical advantage, a dominant color becomes more likely to 'win' and take over the population. However, because the process is random, there will usually be a series of dominant colors before one color finally wins.
+
+Note that once a type of E. coli dies out, it can never come back.
+
+## HOW TO USE IT
+
+The SETUP button initializes the model.
+
+The GO button runs the model.
+
+Use the CARRYING-CAPACITY slider to change the carrying capacity for the world.
+
+Use the TRAITS slider to select the number of competing types of E. coli.
+
+## THINGS TO NOTICE
+
+Notice that colors can achieve a high population count, but still fail to win the race.
+
+Notice that in each simulation, the time required for a single type to become dominant varies. Check to see if an increase or decrease in the carrying capacity has any effect on how fast a color wins.
+
+## THINGS TO TRY
+
+Try and modify the carrying capacity and number of traits to create a somewhat 'balanced' population (every trait has roughly the same population size). Is it even possible?
+
+## EXTENDING THE MODEL
+
+Genetic drift is one mechanism of evolution. The other mechanism is natural selection. Can you incorporate natural selection and make a color of your choice win every time?
+
+## NETLOGO FEATURES
+
+This model uses lots of different `pens` in the Plot editor (right-click on a plot and select 'Edit...') in order to have a multi-color plot.
+
+## RELATED MODELS
+
+* GenDrift Sample Models
+* GenEvo Curricular Models
+
+## HOW TO CITE
+
+If you mention this model or the NetLogo software in a publication, we ask that you include the citations below.
+
+For the model itself:
+
+* Dabholkar, S. and Wilensky, U. (2016).  NetLogo GenEvo 2 Genetic Drift model.  http://ccl.northwestern.edu/netlogo/models/GenEvo2GeneticDrift.  Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+
+Please cite the NetLogo software as:
+
+* Wilensky, U. (1999). NetLogo. http://ccl.northwestern.edu/netlogo/. Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+
+To cite the GenEvo Systems Biology curriculum as a whole, please use:
+
+* Dabholkar, S. & Wilensky, U. (2016). GenEvo Systems Biology curriculum. http://ccl.northwestern.edu/curriculum/genevo/. Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+
+## COPYRIGHT AND LICENSE
+
+Copyright 2016 Uri Wilensky.
+
+![CC BY-NC-SA 3.0](http://ccl.northwestern.edu/images/creativecommons/byncsa.png)
+
+This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 License.  To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/3.0/ or send a letter to Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+
+Commercial licenses are also available. To inquire about commercial licenses, please contact Uri Wilensky at uri@northwestern.edu.
+
+<!-- 2016 GenEvo Cite: Dabholkar, S. -->
+@#$#@#$#@
+default
+true
+0
+Polygon -7500403 true true 150 5 40 250 150 205 260 250
+
+airplane
+true
+0
+Polygon -7500403 true true 150 0 135 15 120 60 120 105 15 165 15 195 120 180 135 240 105 270 120 285 150 270 180 285 210 270 165 240 180 180 285 195 285 165 180 105 180 60 165 15
+
+arrow
+true
+0
+Polygon -7500403 true true 150 0 0 150 105 150 105 293 195 293 195 150 300 150
+
+box
+false
+0
+Polygon -7500403 true true 150 285 285 225 285 75 150 135
+Polygon -7500403 true true 150 135 15 75 150 15 285 75
+Polygon -7500403 true true 15 75 15 225 150 285 150 135
+Line -16777216 false 150 285 150 135
+Line -16777216 false 150 135 15 75
+Line -16777216 false 150 135 285 75
+
+bug
+true
+0
+Circle -7500403 true true 96 182 108
+Circle -7500403 true true 110 127 80
+Circle -7500403 true true 110 75 80
+Line -7500403 true 150 100 80 30
+Line -7500403 true 150 100 220 30
+
+butterfly
+true
+0
+Polygon -7500403 true true 150 165 209 199 225 225 225 255 195 270 165 255 150 240
+Polygon -7500403 true true 150 165 89 198 75 225 75 255 105 270 135 255 150 240
+Polygon -7500403 true true 139 148 100 105 55 90 25 90 10 105 10 135 25 180 40 195 85 194 139 163
+Polygon -7500403 true true 162 150 200 105 245 90 275 90 290 105 290 135 275 180 260 195 215 195 162 165
+Polygon -16777216 true false 150 255 135 225 120 150 135 120 150 105 165 120 180 150 165 225
+Circle -16777216 true false 135 90 30
+Line -16777216 false 150 105 195 60
+Line -16777216 false 150 105 105 60
+
+car
+false
+0
+Polygon -7500403 true true 300 180 279 164 261 144 240 135 226 132 213 106 203 84 185 63 159 50 135 50 75 60 0 150 0 165 0 225 300 225 300 180
+Circle -16777216 true false 180 180 90
+Circle -16777216 true false 30 180 90
+Polygon -16777216 true false 162 80 132 78 134 135 209 135 194 105 189 96 180 89
+Circle -7500403 true true 47 195 58
+Circle -7500403 true true 195 195 58
+
+circle
+false
+0
+Circle -7500403 true true 0 0 300
+
+circle 2
+false
+0
+Circle -7500403 true true 0 0 300
+Circle -16777216 true false 30 30 240
+
+cow
+false
+0
+Polygon -7500403 true true 200 193 197 249 179 249 177 196 166 187 140 189 93 191 78 179 72 211 49 209 48 181 37 149 25 120 25 89 45 72 103 84 179 75 198 76 252 64 272 81 293 103 285 121 255 121 242 118 224 167
+Polygon -7500403 true true 73 210 86 251 62 249 48 208
+Polygon -7500403 true true 25 114 16 195 9 204 23 213 25 200 39 123
+
+cylinder
+false
+0
+Circle -7500403 true true 0 0 300
+
+dot
+false
+0
+
+ecoli
+true
+0
+Rectangle -7500403 true true 75 90 225 210
+Circle -7500403 true true 15 90 120
+Circle -7500403 true true 165 90 120
+
+face happy
+false
+0
+Circle -7500403 true true 8 8 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Polygon -16777216 true false 150 255 90 239 62 213 47 191 67 179 90 203 109 218 150 225 192 218 210 203 227 181 251 194 236 217 212 240
+
+face neutral
+false
+0
+Circle -7500403 true true 8 7 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Rectangle -16777216 true false 60 195 240 225
+
+face sad
+false
+0
+Circle -7500403 true true 8 8 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Polygon -16777216 true false 150 168 90 184 62 210 47 232 67 244 90 220 109 205 150 198 192 205 210 220 227 242 251 229 236 206 212 183
+
+fish
+false
+0
+Polygon -1 true false 44 131 21 87 15 86 0 120 15 150 0 180 13 214 20 212 45 166
+Polygon -1 true false 135 195 119 235 95 218 76 210 46 204 60 165
+Polygon -1 true false 75 45 83 77 71 103 86 114 166 78 135 60
+Polygon -7500403 true true 30 136 151 77 226 81 280 119 292 146 292 160 287 170 270 195 195 210 151 212 30 166
+Circle -16777216 true false 215 106 30
+
+flag
+false
+0
+Rectangle -7500403 true true 60 15 75 300
+Polygon -7500403 true true 90 150 270 90 90 30
+Line -7500403 true 75 135 90 135
+Line -7500403 true 75 45 90 45
+
+flower
+false
+0
+Polygon -10899396 true false 135 120 165 165 180 210 180 240 150 300 165 300 195 240 195 195 165 135
+Circle -7500403 true true 85 132 38
+Circle -7500403 true true 130 147 38
+Circle -7500403 true true 192 85 38
+Circle -7500403 true true 85 40 38
+Circle -7500403 true true 177 40 38
+Circle -7500403 true true 177 132 38
+Circle -7500403 true true 70 85 38
+Circle -7500403 true true 130 25 38
+Circle -7500403 true true 96 51 108
+Circle -16777216 true false 113 68 74
+Polygon -10899396 true false 189 233 219 188 249 173 279 188 234 218
+Polygon -10899396 true false 180 255 150 210 105 210 75 240 135 240
+
+house
+false
+0
+Rectangle -7500403 true true 45 120 255 285
+Rectangle -16777216 true false 120 210 180 285
+Polygon -7500403 true true 15 120 150 15 285 120
+Line -16777216 false 30 120 270 120
+
+leaf
+false
+0
+Polygon -7500403 true true 150 210 135 195 120 210 60 210 30 195 60 180 60 165 15 135 30 120 15 105 40 104 45 90 60 90 90 105 105 120 120 120 105 60 120 60 135 30 150 15 165 30 180 60 195 60 180 120 195 120 210 105 240 90 255 90 263 104 285 105 270 120 285 135 240 165 240 180 270 195 240 210 180 210 165 195
+Polygon -7500403 true true 135 195 135 240 120 255 105 255 105 285 135 285 165 240 165 195
+
+line
+true
+0
+Line -7500403 true 150 0 150 300
+
+line half
+true
+0
+Line -7500403 true 150 0 150 150
+
+pentagon
+false
+0
+Polygon -7500403 true true 150 15 15 120 60 285 240 285 285 120
+
+person
+false
+0
+Circle -7500403 true true 110 5 80
+Polygon -7500403 true true 105 90 120 195 90 285 105 300 135 300 150 225 165 300 195 300 210 285 180 195 195 90
+Rectangle -7500403 true true 127 79 172 94
+Polygon -7500403 true true 195 90 240 150 225 180 165 105
+Polygon -7500403 true true 105 90 60 150 75 180 135 105
+
+plant
+false
+0
+Rectangle -7500403 true true 135 90 165 300
+Polygon -7500403 true true 135 255 90 210 45 195 75 255 135 285
+Polygon -7500403 true true 165 255 210 210 255 195 225 255 165 285
+Polygon -7500403 true true 135 180 90 135 45 120 75 180 135 210
+Polygon -7500403 true true 165 180 165 210 225 180 255 120 210 135
+Polygon -7500403 true true 135 105 90 60 45 45 75 105 135 135
+Polygon -7500403 true true 165 105 165 135 225 105 255 45 210 60
+Polygon -7500403 true true 135 90 120 45 150 15 180 45 165 90
+
+sheep
+false
+15
+Circle -1 true true 203 65 88
+Circle -1 true true 70 65 162
+Circle -1 true true 150 105 120
+Polygon -7500403 true false 218 120 240 165 255 165 278 120
+Circle -7500403 true false 214 72 67
+Rectangle -1 true true 164 223 179 298
+Polygon -1 true true 45 285 30 285 30 240 15 195 45 210
+Circle -1 true true 3 83 150
+Rectangle -1 true true 65 221 80 296
+Polygon -1 true true 195 285 210 285 210 240 240 210 195 210
+Polygon -7500403 true false 276 85 285 105 302 99 294 83
+Polygon -7500403 true false 219 85 210 105 193 99 201 83
+
+square
+false
+0
+Rectangle -7500403 true true 30 30 270 270
+
+square 2
+false
+0
+Rectangle -7500403 true true 30 30 270 270
+Rectangle -16777216 true false 60 60 240 240
+
+star
+false
+0
+Polygon -7500403 true true 151 1 185 108 298 108 207 175 242 282 151 216 59 282 94 175 3 108 116 108
+
+target
+false
+0
+Circle -7500403 true true 0 0 300
+Circle -16777216 true false 30 30 240
+Circle -7500403 true true 60 60 180
+Circle -16777216 true false 90 90 120
+Circle -7500403 true true 120 120 60
+
+tree
+false
+0
+Circle -7500403 true true 118 3 94
+Rectangle -6459832 true false 120 195 180 300
+Circle -7500403 true true 65 21 108
+Circle -7500403 true true 116 41 127
+Circle -7500403 true true 45 90 120
+Circle -7500403 true true 104 74 152
+
+triangle
+false
+0
+Polygon -7500403 true true 150 30 15 255 285 255
+
+triangle 2
+false
+0
+Polygon -7500403 true true 150 30 15 255 285 255
+Polygon -16777216 true false 151 99 225 223 75 224
+
+truck
+false
+0
+Rectangle -7500403 true true 4 45 195 187
+Polygon -7500403 true true 296 193 296 150 259 134 244 104 208 104 207 194
+Rectangle -1 true false 195 60 195 105
+Polygon -16777216 true false 238 112 252 141 219 141 218 112
+Circle -16777216 true false 234 174 42
+Rectangle -7500403 true true 181 185 214 194
+Circle -16777216 true false 144 174 42
+Circle -16777216 true false 24 174 42
+Circle -7500403 false true 24 174 42
+Circle -7500403 false true 144 174 42
+Circle -7500403 false true 234 174 42
+
+turtle
+true
+0
+Polygon -10899396 true false 215 204 240 233 246 254 228 266 215 252 193 210
+Polygon -10899396 true false 195 90 225 75 245 75 260 89 269 108 261 124 240 105 225 105 210 105
+Polygon -10899396 true false 105 90 75 75 55 75 40 89 31 108 39 124 60 105 75 105 90 105
+Polygon -10899396 true false 132 85 134 64 107 51 108 17 150 2 192 18 192 52 169 65 172 87
+Polygon -10899396 true false 85 204 60 233 54 254 72 266 85 252 107 210
+Polygon -7500403 true true 119 75 179 75 209 101 224 135 220 225 175 261 128 261 81 224 74 135 88 99
+
+wheel
+false
+0
+Circle -7500403 true true 3 3 294
+Circle -16777216 true false 30 30 240
+Line -7500403 true 150 285 150 15
+Line -7500403 true 15 150 285 150
+Circle -7500403 true true 120 120 60
+Line -7500403 true 216 40 79 269
+Line -7500403 true 40 84 269 221
+Line -7500403 true 40 216 269 79
+Line -7500403 true 84 40 221 269
+
+wolf
+false
+0
+Polygon -16777216 true false 253 133 245 131 245 133
+Polygon -7500403 true true 2 194 13 197 30 191 38 193 38 205 20 226 20 257 27 265 38 266 40 260 31 253 31 230 60 206 68 198 75 209 66 228 65 243 82 261 84 268 100 267 103 261 77 239 79 231 100 207 98 196 119 201 143 202 160 195 166 210 172 213 173 238 167 251 160 248 154 265 169 264 178 247 186 240 198 260 200 271 217 271 219 262 207 258 195 230 192 198 210 184 227 164 242 144 259 145 284 151 277 141 293 140 299 134 297 127 273 119 270 105
+Polygon -7500403 true true -1 195 14 180 36 166 40 153 53 140 82 131 134 133 159 126 188 115 227 108 236 102 238 98 268 86 269 92 281 87 269 103 269 113
+
+x
+false
+0
+Polygon -7500403 true true 270 75 225 30 30 225 75 270
+Polygon -7500403 true true 30 75 75 30 270 225 225 270
+@#$#@#$#@
+NetLogo 6.0-M9
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+default
+0.0
+-0.2 0 0.0 1.0
+0.0 1 1.0 0.0
+0.2 0 0.0 1.0
+link direction
+true
+0
+Line -7500403 true 150 150 90 180
+Line -7500403 true 150 150 210 180
+@#$#@#$#@
+1
+@#$#@#$#@

--- a/Curricular Models/GenEvo/GenEvo 3 Genetic Drift and Natural Selection.nlogo
+++ b/Curricular Models/GenEvo/GenEvo 3 Genetic Drift and Natural Selection.nlogo
@@ -1,0 +1,642 @@
+breed [ ecolis ecoli ]
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;; SETUP PROCEDURES ;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+to setup   ; Sets up the population of bacteria (E. coli) randomly across the world.
+  clear-all
+  let color-list [ gray red brown yellow green cyan violet magenta ]
+
+  create-ecolis number-of-traits [
+    set shape "ecoli"
+    setxy random-xcor random-ycor
+    set color first color-list
+    set color-list but-first color-list ; each type has a unique color so we remove this color form our list
+  ]
+
+  reset-ticks
+end
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;; RUNTIME PROCEDURES ;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+to go
+  ask ecolis [
+    move
+    reproduce
+    check-if-dead
+  ]
+  tick
+end
+
+to move  ; E. coli cells move randomly across the world.
+  rt random-float 360
+  fd 1
+end
+
+to reproduce    ; E. coli cells reproduce based on % selective advantage when Natural-Selection? is ON.
+
+  ifelse natural-selection? [
+
+    ; we have to use `runresult` here in order to compare, for example, the string "magenta" to the primitive `magenta`
+    ifelse color = runresult faster-reproducing-ecoli [
+
+      ; When the natural selection is ON, Faster_reproducing E. coli cells
+      ; have higher chance of reproduction based on % selective advantage.
+      if random-float 100 > ( 99 - ( selective-advantage / 100 ) ) [
+        hatch 1 [rt random-float 360 fd 1]
+      ]
+    ]
+    [
+      if random-float 100 > 99 [
+        hatch 1 [rt random-float 360 fd 1]
+      ]
+    ]
+  ]
+  [
+    ask ecolis [    ; When natural selection is OFF, all E. coli cells have same chance of reproducing.
+      if random-float 100 > 99 [
+        hatch 1 [rt random-float 360 fd 1]
+      ]
+    ]
+  ]
+end
+
+to check-if-dead       ;; random chance of death when the total population exceeds carrying capacity
+  if random count ecolis > carrying-capacity [
+    die
+  ]
+end
+
+
+; Copyright 2016 Uri Wilensky.
+; See Info tab for full copyright and license.
+@#$#@#$#@
+GRAPHICS-WINDOW
+500
+10
+970
+481
+-1
+-1
+14.0
+1
+10
+1
+1
+1
+0
+0
+0
+1
+-16
+16
+-16
+16
+1
+1
+1
+ticks
+30.0
+
+BUTTON
+15
+10
+122
+55
+NIL
+setup
+NIL
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+1
+
+BUTTON
+135
+10
+246
+55
+NIL
+go\n
+T
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+0
+
+PLOT
+15
+170
+488
+480
+Population Dynamics Graph
+Time
+Frequency
+0.0
+10.0
+0.0
+10.0
+true
+true
+"" ""
+PENS
+"gray" 1.0 0 -7500403 true "" "plot count ecolis with [ color = gray ]"
+"red" 1.0 0 -2674135 true "" "plot count ecolis with [ color = red ]"
+"brown" 1.0 0 -6459832 true "" "plot count ecolis with [ color = brown ]"
+"yellow" 1.0 0 -1184463 true "" "plot count ecolis with [ color = yellow ]"
+"green" 1.0 0 -10899396 true "" "plot count ecolis with [ color = green ]"
+"cyan" 1.0 0 -11221820 true "" "plot count ecolis with [ color = cyan ]"
+"violet" 1.0 0 -8630108 true "" "plot count ecolis with [ color = violet ]"
+"magenta" 1.0 0 -5825686 true "" "plot count ecolis with [ color = magenta ]"
+
+SLIDER
+14
+65
+245
+98
+carrying-capacity
+carrying-capacity
+0
+500
+300.0
+10
+1
+NIL
+HORIZONTAL
+
+SWITCH
+255
+20
+489
+53
+natural-selection?
+natural-selection?
+0
+1
+-1000
+
+SLIDER
+250
+110
+489
+143
+selective-advantage
+selective-advantage
+0
+10
+3.0
+1
+1
+%
+HORIZONTAL
+
+SLIDER
+255
+65
+491
+98
+number-of-traits
+number-of-traits
+2
+8
+8.0
+1
+1
+NIL
+HORIZONTAL
+
+CHOOSER
+15
+110
+240
+155
+faster-reproducing-ecoli
+faster-reproducing-ecoli
+"gray" "red" "brown" "yellow" "green" "cyan" "violet" "magenta"
+0
+
+@#$#@#$#@
+## WHAT IS IT?
+
+This model allows for the exploration and comparison of two different mechanisms of evolution: natural selection and genetic drift. It models evolution in a population of asexually reproducing bacteria, E. coli.
+
+It starts with different types of E. coli, each with a different trait represented by different colors. When ‘natural selection’ is off, the model shows that competing types of E. coli, each reproducing with equal likelihood on each turn, will ultimately converge on one type without any selection pressure forcing this convergence. This is called genetic drift, an idea explained in more detail in Dennett's _Darwin's Dangerous Idea_ that explains that trait drifts can occur without any particular purpose or 'selecting pressure'. An important thing to note is this model includes only one case of natural selection called _r-selection_.
+
+## HOW IT WORKS
+
+The model starts with different colored E. coli cells, randomly distributed across the world. The user can select the number of different colors (types) of cells to start with. The cells can then move randomly across the world. Then,
+
+When Natural Selection is OFF:
+
+Each turn, each E. coli has the same likelihood of reproducing to form two daughter cells of its type (of the same color).  If the total number of E. coli is greater than the carrying capacity of the system, then some E. coli cells are randomly killed in order to maintain that carrying capacity. By statistical advantage, a dominant color becomes more likely to 'win out', however, because the process is random, there will usually be a number of temporarily dominant colors before one color finally wins.
+
+When Natural Selection is ON:
+
+A user can select which trait (color) has a selective advantage in this world, causing it to reproduce faster. This selective advantage sets the percentage by which a type's reproduction rate (modelled here by the chance to reproduce during each tick) is higher than the others. Through this selective advantage, a dominant color becomes more likely to 'win out'. However, if the selective advantage is low, statistical advantage might still cause another color to 'win out'.
+
+Note that once a color dies out, it can never come back.
+
+## HOW TO USE IT
+
+The SETUP button initializes the model.
+
+The GO button runs the model.
+
+Use CARRYING-CAPACITY slider to change the carrying capacity for the world.
+
+Use the NUMBER-OF-TRAITS slider to select the number of competing colors.
+
+Use the FASTER-REPRODUCING-ECOLI chooser to select the color (type) of E. coli that has a selective advantage.
+
+Use the SELECTIVE-ADVANTAGE slider to set % increase in reproduction rate of "Faster reproducing E. coli" as compared to others.
+
+## THINGS TO NOTICE
+
+Notice that the faster reproducing color with selective advantage often wins the race when the % selective advantage is high. When the % selective advantage is low, statistical advantage in favor of any of the other colors might result in different outcomes. Check if there is any tipping point above which % selective advantage always makes the color win.
+
+## THINGS TO TRY
+
+In each simulation, the time required for a single type to become dominant varies. Check to see if an increase or decrease in the carrying capacity has any effect on how fast a color wins. Now check this same phenomenon in the presence and absence of  natural selection.
+
+## EXTENDING THE MODEL
+
+The type of natural selection incorporated in this model is _r-selection_. The other possible type is _k-selection_. Think about how you could incorporate k-selection in this model.
+
+## NETLOGO FEATURES
+
+This model uses the `runresult` primitive in order to convert your color selection (a `string`) into a NetLogo color (a number).
+
+## RELATED MODELS
+
+* GenDrift Sample Models
+* GenEvo Curricular Models
+
+## HOW TO CITE
+
+If you mention this model or the NetLogo software in a publication, we ask that you include the citations below.
+
+For the model itself:
+
+* Dabholkar, S. and Wilensky, U. (2016).  NetLogo GenEvo 3 Genetic Drift and Natural Selection model.  http://ccl.northwestern.edu/netlogo/models/GenEvo3GeneticDriftandNaturalSelection.  Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+
+Please cite the NetLogo software as:
+
+* Wilensky, U. (1999). NetLogo. http://ccl.northwestern.edu/netlogo/. Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+
+To cite the GenEvo Systems Biology curriculum as a whole, please use:
+
+* Dabholkar, S. & Wilensky, U. (2016). GenEvo Systems Biology curriculum. http://ccl.northwestern.edu/curriculum/genevo/. Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+
+## COPYRIGHT AND LICENSE
+
+Copyright 2016 Uri Wilensky.
+
+![CC BY-NC-SA 3.0](http://ccl.northwestern.edu/images/creativecommons/byncsa.png)
+
+This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 License.  To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/3.0/ or send a letter to Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+
+Commercial licenses are also available. To inquire about commercial licenses, please contact Uri Wilensky at uri@northwestern.edu.
+
+<!-- 2016 GenEvo Cite: Dabholkar, S. -->
+@#$#@#$#@
+default
+true
+0
+Polygon -7500403 true true 150 5 40 250 150 205 260 250
+
+airplane
+true
+0
+Polygon -7500403 true true 150 0 135 15 120 60 120 105 15 165 15 195 120 180 135 240 105 270 120 285 150 270 180 285 210 270 165 240 180 180 285 195 285 165 180 105 180 60 165 15
+
+arrow
+true
+0
+Polygon -7500403 true true 150 0 0 150 105 150 105 293 195 293 195 150 300 150
+
+box
+false
+0
+Polygon -7500403 true true 150 285 285 225 285 75 150 135
+Polygon -7500403 true true 150 135 15 75 150 15 285 75
+Polygon -7500403 true true 15 75 15 225 150 285 150 135
+Line -16777216 false 150 285 150 135
+Line -16777216 false 150 135 15 75
+Line -16777216 false 150 135 285 75
+
+bug
+true
+0
+Circle -7500403 true true 96 182 108
+Circle -7500403 true true 110 127 80
+Circle -7500403 true true 110 75 80
+Line -7500403 true 150 100 80 30
+Line -7500403 true 150 100 220 30
+
+butterfly
+true
+0
+Polygon -7500403 true true 150 165 209 199 225 225 225 255 195 270 165 255 150 240
+Polygon -7500403 true true 150 165 89 198 75 225 75 255 105 270 135 255 150 240
+Polygon -7500403 true true 139 148 100 105 55 90 25 90 10 105 10 135 25 180 40 195 85 194 139 163
+Polygon -7500403 true true 162 150 200 105 245 90 275 90 290 105 290 135 275 180 260 195 215 195 162 165
+Polygon -16777216 true false 150 255 135 225 120 150 135 120 150 105 165 120 180 150 165 225
+Circle -16777216 true false 135 90 30
+Line -16777216 false 150 105 195 60
+Line -16777216 false 150 105 105 60
+
+car
+false
+0
+Polygon -7500403 true true 300 180 279 164 261 144 240 135 226 132 213 106 203 84 185 63 159 50 135 50 75 60 0 150 0 165 0 225 300 225 300 180
+Circle -16777216 true false 180 180 90
+Circle -16777216 true false 30 180 90
+Polygon -16777216 true false 162 80 132 78 134 135 209 135 194 105 189 96 180 89
+Circle -7500403 true true 47 195 58
+Circle -7500403 true true 195 195 58
+
+circle
+false
+0
+Circle -7500403 true true 0 0 300
+
+circle 2
+false
+0
+Circle -7500403 true true 0 0 300
+Circle -16777216 true false 30 30 240
+
+cow
+false
+0
+Polygon -7500403 true true 200 193 197 249 179 249 177 196 166 187 140 189 93 191 78 179 72 211 49 209 48 181 37 149 25 120 25 89 45 72 103 84 179 75 198 76 252 64 272 81 293 103 285 121 255 121 242 118 224 167
+Polygon -7500403 true true 73 210 86 251 62 249 48 208
+Polygon -7500403 true true 25 114 16 195 9 204 23 213 25 200 39 123
+
+cylinder
+false
+0
+Circle -7500403 true true 0 0 300
+
+dot
+false
+0
+
+ecoli
+true
+0
+Rectangle -7500403 true true 75 90 225 210
+Circle -7500403 true true 15 90 120
+Circle -7500403 true true 165 90 120
+
+face happy
+false
+0
+Circle -7500403 true true 8 8 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Polygon -16777216 true false 150 255 90 239 62 213 47 191 67 179 90 203 109 218 150 225 192 218 210 203 227 181 251 194 236 217 212 240
+
+face neutral
+false
+0
+Circle -7500403 true true 8 7 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Rectangle -16777216 true false 60 195 240 225
+
+face sad
+false
+0
+Circle -7500403 true true 8 8 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Polygon -16777216 true false 150 168 90 184 62 210 47 232 67 244 90 220 109 205 150 198 192 205 210 220 227 242 251 229 236 206 212 183
+
+fish
+false
+0
+Polygon -1 true false 44 131 21 87 15 86 0 120 15 150 0 180 13 214 20 212 45 166
+Polygon -1 true false 135 195 119 235 95 218 76 210 46 204 60 165
+Polygon -1 true false 75 45 83 77 71 103 86 114 166 78 135 60
+Polygon -7500403 true true 30 136 151 77 226 81 280 119 292 146 292 160 287 170 270 195 195 210 151 212 30 166
+Circle -16777216 true false 215 106 30
+
+flag
+false
+0
+Rectangle -7500403 true true 60 15 75 300
+Polygon -7500403 true true 90 150 270 90 90 30
+Line -7500403 true 75 135 90 135
+Line -7500403 true 75 45 90 45
+
+flower
+false
+0
+Polygon -10899396 true false 135 120 165 165 180 210 180 240 150 300 165 300 195 240 195 195 165 135
+Circle -7500403 true true 85 132 38
+Circle -7500403 true true 130 147 38
+Circle -7500403 true true 192 85 38
+Circle -7500403 true true 85 40 38
+Circle -7500403 true true 177 40 38
+Circle -7500403 true true 177 132 38
+Circle -7500403 true true 70 85 38
+Circle -7500403 true true 130 25 38
+Circle -7500403 true true 96 51 108
+Circle -16777216 true false 113 68 74
+Polygon -10899396 true false 189 233 219 188 249 173 279 188 234 218
+Polygon -10899396 true false 180 255 150 210 105 210 75 240 135 240
+
+house
+false
+0
+Rectangle -7500403 true true 45 120 255 285
+Rectangle -16777216 true false 120 210 180 285
+Polygon -7500403 true true 15 120 150 15 285 120
+Line -16777216 false 30 120 270 120
+
+leaf
+false
+0
+Polygon -7500403 true true 150 210 135 195 120 210 60 210 30 195 60 180 60 165 15 135 30 120 15 105 40 104 45 90 60 90 90 105 105 120 120 120 105 60 120 60 135 30 150 15 165 30 180 60 195 60 180 120 195 120 210 105 240 90 255 90 263 104 285 105 270 120 285 135 240 165 240 180 270 195 240 210 180 210 165 195
+Polygon -7500403 true true 135 195 135 240 120 255 105 255 105 285 135 285 165 240 165 195
+
+line
+true
+0
+Line -7500403 true 150 0 150 300
+
+line half
+true
+0
+Line -7500403 true 150 0 150 150
+
+pentagon
+false
+0
+Polygon -7500403 true true 150 15 15 120 60 285 240 285 285 120
+
+person
+false
+0
+Circle -7500403 true true 110 5 80
+Polygon -7500403 true true 105 90 120 195 90 285 105 300 135 300 150 225 165 300 195 300 210 285 180 195 195 90
+Rectangle -7500403 true true 127 79 172 94
+Polygon -7500403 true true 195 90 240 150 225 180 165 105
+Polygon -7500403 true true 105 90 60 150 75 180 135 105
+
+plant
+false
+0
+Rectangle -7500403 true true 135 90 165 300
+Polygon -7500403 true true 135 255 90 210 45 195 75 255 135 285
+Polygon -7500403 true true 165 255 210 210 255 195 225 255 165 285
+Polygon -7500403 true true 135 180 90 135 45 120 75 180 135 210
+Polygon -7500403 true true 165 180 165 210 225 180 255 120 210 135
+Polygon -7500403 true true 135 105 90 60 45 45 75 105 135 135
+Polygon -7500403 true true 165 105 165 135 225 105 255 45 210 60
+Polygon -7500403 true true 135 90 120 45 150 15 180 45 165 90
+
+sheep
+false
+15
+Circle -1 true true 203 65 88
+Circle -1 true true 70 65 162
+Circle -1 true true 150 105 120
+Polygon -7500403 true false 218 120 240 165 255 165 278 120
+Circle -7500403 true false 214 72 67
+Rectangle -1 true true 164 223 179 298
+Polygon -1 true true 45 285 30 285 30 240 15 195 45 210
+Circle -1 true true 3 83 150
+Rectangle -1 true true 65 221 80 296
+Polygon -1 true true 195 285 210 285 210 240 240 210 195 210
+Polygon -7500403 true false 276 85 285 105 302 99 294 83
+Polygon -7500403 true false 219 85 210 105 193 99 201 83
+
+square
+false
+0
+Rectangle -7500403 true true 30 30 270 270
+
+square 2
+false
+0
+Rectangle -7500403 true true 30 30 270 270
+Rectangle -16777216 true false 60 60 240 240
+
+star
+false
+0
+Polygon -7500403 true true 151 1 185 108 298 108 207 175 242 282 151 216 59 282 94 175 3 108 116 108
+
+target
+false
+0
+Circle -7500403 true true 0 0 300
+Circle -16777216 true false 30 30 240
+Circle -7500403 true true 60 60 180
+Circle -16777216 true false 90 90 120
+Circle -7500403 true true 120 120 60
+
+tree
+false
+0
+Circle -7500403 true true 118 3 94
+Rectangle -6459832 true false 120 195 180 300
+Circle -7500403 true true 65 21 108
+Circle -7500403 true true 116 41 127
+Circle -7500403 true true 45 90 120
+Circle -7500403 true true 104 74 152
+
+triangle
+false
+0
+Polygon -7500403 true true 150 30 15 255 285 255
+
+triangle 2
+false
+0
+Polygon -7500403 true true 150 30 15 255 285 255
+Polygon -16777216 true false 151 99 225 223 75 224
+
+truck
+false
+0
+Rectangle -7500403 true true 4 45 195 187
+Polygon -7500403 true true 296 193 296 150 259 134 244 104 208 104 207 194
+Rectangle -1 true false 195 60 195 105
+Polygon -16777216 true false 238 112 252 141 219 141 218 112
+Circle -16777216 true false 234 174 42
+Rectangle -7500403 true true 181 185 214 194
+Circle -16777216 true false 144 174 42
+Circle -16777216 true false 24 174 42
+Circle -7500403 false true 24 174 42
+Circle -7500403 false true 144 174 42
+Circle -7500403 false true 234 174 42
+
+turtle
+true
+0
+Polygon -10899396 true false 215 204 240 233 246 254 228 266 215 252 193 210
+Polygon -10899396 true false 195 90 225 75 245 75 260 89 269 108 261 124 240 105 225 105 210 105
+Polygon -10899396 true false 105 90 75 75 55 75 40 89 31 108 39 124 60 105 75 105 90 105
+Polygon -10899396 true false 132 85 134 64 107 51 108 17 150 2 192 18 192 52 169 65 172 87
+Polygon -10899396 true false 85 204 60 233 54 254 72 266 85 252 107 210
+Polygon -7500403 true true 119 75 179 75 209 101 224 135 220 225 175 261 128 261 81 224 74 135 88 99
+
+wheel
+false
+0
+Circle -7500403 true true 3 3 294
+Circle -16777216 true false 30 30 240
+Line -7500403 true 150 285 150 15
+Line -7500403 true 15 150 285 150
+Circle -7500403 true true 120 120 60
+Line -7500403 true 216 40 79 269
+Line -7500403 true 40 84 269 221
+Line -7500403 true 40 216 269 79
+Line -7500403 true 84 40 221 269
+
+wolf
+false
+0
+Polygon -16777216 true false 253 133 245 131 245 133
+Polygon -7500403 true true 2 194 13 197 30 191 38 193 38 205 20 226 20 257 27 265 38 266 40 260 31 253 31 230 60 206 68 198 75 209 66 228 65 243 82 261 84 268 100 267 103 261 77 239 79 231 100 207 98 196 119 201 143 202 160 195 166 210 172 213 173 238 167 251 160 248 154 265 169 264 178 247 186 240 198 260 200 271 217 271 219 262 207 258 195 230 192 198 210 184 227 164 242 144 259 145 284 151 277 141 293 140 299 134 297 127 273 119 270 105
+Polygon -7500403 true true -1 195 14 180 36 166 40 153 53 140 82 131 134 133 159 126 188 115 227 108 236 102 238 98 268 86 269 92 281 87 269 103 269 113
+
+x
+false
+0
+Polygon -7500403 true true 270 75 225 30 30 225 75 270
+Polygon -7500403 true true 30 75 75 30 270 225 225 270
+@#$#@#$#@
+NetLogo 6.0-M9
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+default
+0.0
+-0.2 0 0.0 1.0
+0.0 1 1.0 0.0
+0.2 0 0.0 1.0
+link direction
+true
+0
+Line -7500403 true 150 150 90 180
+Line -7500403 true 150 150 210 180
+@#$#@#$#@
+1
+@#$#@#$#@

--- a/Curricular Models/GenEvo/GenEvo 4 Competition.nlogo
+++ b/Curricular Models/GenEvo/GenEvo 4 Competition.nlogo
@@ -251,7 +251,7 @@ NIL
 NIL
 NIL
 NIL
-1
+0
 
 PLOT
 5
@@ -330,7 +330,7 @@ NIL
 NIL
 NIL
 NIL
-1
+0
 
 PLOT
 5

--- a/Curricular Models/GenEvo/GenEvo 4 Competition.nlogo
+++ b/Curricular Models/GenEvo/GenEvo 4 Competition.nlogo
@@ -1,0 +1,805 @@
+extensions [ ls cf ]
+
+globals [
+  ; These are constant variables used to specify simulation restrictions
+  global-lactose-limit         ; variable to specify lactose quantity
+  initial-energy               ; variable to specify initial energy of bacterial cells
+]
+
+breed [ ecolis ecoli ]
+
+ecolis-own [
+  my-model              ; cell model (LevelSpace child model) associated with an E. coli cell
+  my-model-path         ; path to locate the file to be loaded as a cell model (LevelSpace child model)
+
+  ; these variables are used to store the corresponding statistics from the cell models
+  energy                ; energy of the cell
+  lactose-inside        ; lactose quantity inside a cell
+  lactose-outside       ; lactose quantity in the outside environment
+  lacZ-inside           ; lacZ proteins inside a cell
+  lacY-inside           ; lacY proteins inside a cell
+  lacY-inserted         ; lacY proteins inserted into the cell-wall
+  lacI-lactose-complex  ; lacI-lactose-complex molecules inside a cell
+]
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;; SETUP PROCEDURES ;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+to setup
+  clear-all
+  ls:reset
+  ; set the constant values
+  set initial-energy 1000
+  set global-lactose-limit (initial-number-of-cells * 5000)
+  generate-cells ; create the cells
+  if lactose? [ distribute-lactose ] ; distribute lactose if the option is selected
+  reset-ticks
+end
+
+; procedure to generate E. coli cells. If choose-models is OFF, default cell model is loaded for all the cells.
+to generate-cells
+  let color-list [ gray red brown yellow green cyan violet magenta ]
+
+  let i 0
+  create-ecolis initial-number-of-cells [
+    set color (item i color-list)
+    setxy random-xcor random-ycor
+    set shape "ecoli"
+
+    ifelse choose-models? [
+      user-message "Select a Genetic Switch model to load..."
+      set my-model-path user-file
+    ][
+      set my-model-path "GenEvo 1 Genetic Switch.nlogo"
+    ]
+
+    load-my-model
+    while [ test-if-switch my-model ] [
+      user-message "The model must be a Genetic Switch model! Please select a Genetic Switch model again."
+      ls:close my-model
+      set my-model-path user-file
+      load-my-model
+    ]
+    set i i + 1
+  ]
+end
+
+to load-my-model ; turtle procedure
+  ; If my-model-path is False, it means the user didn't select a file.
+  ; In that case, we kill the E. coli so we this doesn't mess anything up.
+  ifelse my-model-path != False [
+    ls:load-gui-model my-model-path
+    set my-model last ls:models
+    ls:hide my-model
+
+    ls:let initial-variables-list generate-initial-variables-list
+    ls:ask my-model [
+      setup
+      set-initial-variables initial-variables-list
+    ]
+  ]
+  [ die ]
+end
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;; RUNTIME PROCEDURES ;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+to go
+  distribute-lactose
+  ask ecolis [
+    rt random-float 360
+    fd 1
+    run-your-model
+    maybe-reproduce
+    if energy < 0 [
+      ls:close my-model
+      die
+    ]
+  ]
+  if not any? ecolis [ stop ]
+  tick
+end
+
+; Updates the enviornmental conditions and then runs each cell model
+to run-your-model ; turtle procedure
+   ls:let lactose-outside-per-cell ifelse-value lactose? [ floor ( global-lactose-limit / length ls:models ) ] [ 0 ]
+   ls:let parent-glucose? glucose?
+   ls:let parent-lactose? lactose?
+
+   ls:ask my-model [
+     set glucose? parent-glucose?
+     set lactose? parent-lactose?
+     go
+   ]
+end
+
+; when lactose? is OFF, this procedure is used to update the lactose quantity in the environment in the population model
+to distribute-lactose
+  ifelse lactose? [
+    ls:let lactose-per-model (global-lactose-limit / length ls:models)
+    ask patches [ set pcolor 2 ]
+    ask ecolis [ ls:ask my-model [ update-lactose lactose-per-model ] ]
+  ][
+    ; see how much lactose is outside all of the cells
+    let total-lactose-outside sum [ count lactoses with [ not inside? ] ] ls:of ls:models
+
+    cf:when ; color the patches based on the global lactose amount
+    cf:case [ total-lactose-outside < (global-lactose-limit / 2) ] [ ask patches [ set pcolor 1 ]]
+    cf:case [ total-lactose-outside = 0 ] [ ask patches [ set pcolor 0 ] ]
+    cf:else [ ask patches [ set pcolor 2 ] ]
+
+    ls:let lactose-per-model (total-lactose-outside / length ls:models)
+    ask ecolis [ ls:ask my-model [ update-lactose lactose-per-model ] ]
+  ]
+end
+
+; procedure for E. coli cells to reproduce. A new cell is added in the population model and a new individual cell model is loaded.
+to maybe-reproduce
+  ; if there's enough energy, reproduce
+  if ( [ energy ] ls:of my-model > 2 * initial-energy ) [
+    ls:ask my-model [ divide-cell ]
+    extract-cell-model-variables
+    hatch 1 [
+      rt random-float 360 fd 1 ; move it forward so they don't overlap
+      load-my-model  ; Now load and setup the cell model that will simulate this new daughter cell
+    ]
+  ]
+end
+
+; procedure to concatenate all the necessary initial variables for a daughter cell model into a single list
+to-report generate-initial-variables-list ; turtle procedure
+  report (list color initial-energy lacY-inside lacY-inserted lacZ-inside lacI-lactose-complex lactose-inside lactose-outside lactose? glucose?)
+end
+
+; Extract all the necessary variables from the cell model
+to extract-cell-model-variables ; turtle procedure
+
+  let list-of-variables ([ send-variables-list ] ls:of my-model) ; grab the list
+
+  ; now save the elements in our 'ecolis-own' variables
+  set energy item 0 list-of-variables
+  set lacY-inside item 1 list-of-variables
+  set lacY-inserted item 2 list-of-variables
+  set lacZ-inside item 3 list-of-variables
+  set lacI-lactose-complex item 4 list-of-variables
+  set lactose-inside item 5 list-of-variables
+  set lactose-outside item 6 list-of-variables
+end
+
+; procedure to view the cell model (LevelSpace child model) associated with each cell
+to inspect-cells
+  if mouse-inside? and mouse-down? [
+    ask ecolis with-min [ distancexy mouse-xcor mouse-ycor ] [
+      ls:show my-model
+    ]
+  ]
+end
+
+; procedure to test whether or not a model is a Genetic Switch model
+to-report test-if-switch [ a-model-number ]
+  let return-value False
+  carefully [
+    ls:ask a-model-number [ set LevelSpace? True ]
+  ][
+     set return-value True
+   ]
+  report return-value
+end
+
+
+; Copyright 2016 Uri Wilensky.
+; See Info tab for full copyright and license.
+@#$#@#$#@
+GRAPHICS-WINDOW
+465
+10
+968
+514
+-1
+-1
+15.0
+1
+10
+1
+1
+1
+0
+0
+0
+1
+-16
+16
+-16
+16
+1
+1
+1
+ticks
+30.0
+
+BUTTON
+5
+10
+75
+45
+NIL
+setup
+NIL
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+1
+
+BUTTON
+79
+10
+135
+45
+go
+go\n
+T
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+1
+
+PLOT
+5
+90
+460
+315
+Population
+Time
+Frequency
+0.0
+10.0
+10.0
+10.0
+true
+true
+"" ""
+PENS
+"gray" 1.0 0 -7500403 true "" "plot count ecolis with [ color = gray ]"
+"red" 1.0 0 -2674135 true "" "if initial-number-of-cells > 1 [ plot count ecolis with [ color = red ] ]"
+"brown" 1.0 0 -6459832 true "" "if initial-number-of-cells > 2 [ plot count ecolis with [ color = brown ] ]"
+"yellow" 1.0 0 -1184463 true "" "if initial-number-of-cells > 3 [ plot count ecolis with [ color = yellow ] ]"
+"green" 1.0 0 -10899396 true "" "if initial-number-of-cells > 4 [ plot count ecolis with [ color = green ] ]"
+"cyan" 1.0 0 -11221820 true "" "if initial-number-of-cells > 5 [ plot count ecolis with [ color = cyan ] ]"
+"violet" 1.0 0 -8630108 true "" "if initial-number-of-cells > 6 [ plot count ecolis with [ color = violet ] ]"
+"magenta" 1.0 0 -5825686 true "" "if initial-number-of-cells > 7 [ plot count ecolis with [ color = magenta ] ]"
+
+SWITCH
+140
+10
+255
+43
+lactose?
+lactose?
+0
+1
+-1000
+
+SLIDER
+260
+50
+460
+83
+initial-number-of-cells
+initial-number-of-cells
+1
+8
+3.0
+1
+1
+NIL
+HORIZONTAL
+
+SWITCH
+140
+50
+255
+83
+glucose?
+glucose?
+1
+1
+-1000
+
+BUTTON
+5
+50
+135
+83
+inspect cells
+inspect-cells
+T
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+1
+
+PLOT
+5
+320
+460
+514
+Trait Distribution Histogram
+Trait
+Frequency
+0.0
+10.0
+0.0
+10.0
+true
+false
+"" ""
+PENS
+"gray" 1.0 1 -7500403 true "" "histogram [ 1 ] of ecolis with [ color = gray ]"
+"red" 1.0 1 -2674135 true "" "histogram [ 2 ] of ecolis with [ color = red ]"
+"brown" 1.0 1 -6459832 true "" "histogram [ 3 ] of ecolis with [ color = brown ]"
+"yellow" 1.0 1 -1184463 true "" "histogram [ 4 ] of ecolis with [ color = yellow ]"
+"green" 1.0 1 -10899396 true "" "histogram [ 4 ] of ecolis with [ color = green ]"
+"cyan" 1.0 1 -11221820 true "" "histogram [ 5 ] of ecolis with [ color = cyan ]"
+"violet" 1.0 1 -8630108 true "" "histogram [ 6 ] of ecolis with [ color = violet ]"
+"magenta" 1.0 1 -5825686 true "" "histogram [ 7 ] of ecolis with [ color = magenta ]"
+
+SWITCH
+260
+10
+460
+43
+choose-models?
+choose-models?
+1
+1
+-1000
+
+@#$#@#$#@
+## WHAT IS IT?
+
+This is a population model of competition between cells in a population of asexually reproducing bacteria E. coli for resources in an environment. Users can experiment with various parameters to learn more about two different mechanisms of evolution: natural selection and genetic drift.
+
+## HOW IT WORKS
+
+Using the LevelSpace extension of NetLogo, each cell in this population model is actually controlled by a genetic switch model (just like _GenEvo 1_). In LevelSpace terminology, this population model is called a _parent model_ and each cell is a _child model_. However, in this info section, we will call this model the _population model_ and each background genetic switch model a _cell model_.
+
+Depending on the selected options, each cell model begins with a different set of initial parameters. Then, each cell model simulates the DNA-Protein interactions in the lac-operon of E. coli (check out the _GenEvo 1_ model for a refresher). In the population model, we see the competition for resources between these cells.
+
+When a cell's energy level doubles from its initial level, the cell produces two daughter cells that inherit the cell's genetic and epigenetic information. The cells with a 'fitter' genetic circuit turn their switch on and off faster, resulting in a faster increase in the energy levels, and a faster growth rate.
+
+Because the molecular interactions in each cell model are stochastic, the population model displays the effects of both natural and statistical selection (genetic drift).
+
+## HOW TO USE IT
+
+### To Setup
+
+You can use this model in two ways.
+
+1. The simplest way to use this model is to set CHOOSE-MODELS? to OFF. In this mode, the default Genetic Switch model is loaded for each cell. This method simulates genetic drift as a mechanism of evolution since each cell starts off identical.
+
+2. If CHOOSE-MODELS? is ON, a user can manually select the NetLogo models (`.nlogo` files) to be loaded for each cell, allowing each cell to have a different genetic switch. This allows for variability in the population. This method simulates natural selection as well as genetic drift.
+
+In both ways, the SETUP button sets up the population of E. coli cells (each type represented by a unique color) and randomly distributes them across the world.
+
+### To run
+
+After you setup the model, set the environmental conditions by setting LACTOSE? and GLUCOSE? to ON or OFF.
+
+Click GO to run the population model (and consequently, the cell models) for around 300 ticks. Click GO again to pause the model. Click INSPECT CELLS and click on any cell to see the cell model behind it. Close the individual cell models (Always select 'run in the background' option when closing individual models). Click GO to run the model again.
+
+Change the environmental conditions using the LACTOSE? and GLUCOSE? switches and observe the different behaviors of population. (Note: You have to run the model for a few hundred ticks in order to observe cellular behavior.)
+
+### Buttons
+
+SETUP - Sets up the population model and cell models
+
+GO - Makes the simulation in the population model (and consequently the cell models) begin to tick
+
+INSPECT-CELLS - This button allows you to open the cell model of any cell in the population model. Click the button first and then click on a cell to see its cell model. When you close an individual cell model, always select the 'run in the background' option.
+
+### Switches
+
+LACTOSE? - If ON, lactose is added to the external environment and equally distributed among the cell models. This means that the more the cells, the less lactose each cell gets. In other words, this is how we model carrying capacity.
+
+GLUCOSE? - If ON, glucose is added to the external environment. Transport and digestion of glucose is not explicitly modeled, however since glucose is a _preferred sugar_, when glucose is present the _lac promoter_ in the Genetic Switch model is inactive. In addition, when glucose is present, the energy of each cell increases with a constant rate (10 units per tick).
+
+### Sliders
+
+INITIAL-NUMBER-OF-CELLS – This is the initial number of cells in the population model. If CHOOSE-MODELS? is ON, this also corresponds to the number of Genetic Switch models the user has to select.
+
+## THINGS TO NOTICE
+
+Notice the reproduction of cells as the time progresses. Notice how each cell model behaves with different sugar conditions.
+
+Run the model for a few thousand ticks to see which cell type wins. Notice the cellular behavior of the Genetic Switch in the different types of cells by using the INSPECT CELLS button. Run the simulation several times with the same set of cell models to distinguish between the roles of natural selection and genetic drift. If natural selection is a stronger mechanism for evolution in a given set of cell models, then the same trait will win more frequently.
+
+## THINGS TO TRY
+
+See if you can make the background color of the view scale with how much lactose and glucose are in the medium.
+
+## EXTENDING THE MODEL
+
+See if you can modify the model to model the effect of glucose explicitly by introducing the requisite proteins.
+
+## NETLOGO FEATURES
+
+This model uses the LevelSpace extension to allow each cell to have its own genetic switch model controlling the protein interactions within.
+
+## RELATED MODELS
+
+* GenDrift Sample Models
+* GenEvo Curricular Models
+
+## HOW TO CITE
+
+If you mention this model or the NetLogo software in a publication, we ask that you include the citations below.
+
+For the model itself:
+
+* Dabholkar, S. and Wilensky, U. (2016).  NetLogo GenEvo 4 Competition model.  http://ccl.northwestern.edu/netlogo/models/GenEvo4Competition.  Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+
+Please cite the NetLogo software as:
+
+* Wilensky, U. (1999). NetLogo. http://ccl.northwestern.edu/netlogo/. Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+
+To cite the GenEvo Systems Biology curriculum as a whole, please use:
+
+* Dabholkar, S. & Wilensky, U. (2016). GenEvo Systems Biology curriculum. http://ccl.northwestern.edu/curriculum/genevo/. Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.
+
+## COPYRIGHT AND LICENSE
+
+Copyright 2016 Uri Wilensky.
+
+![CC BY-NC-SA 3.0](http://ccl.northwestern.edu/images/creativecommons/byncsa.png)
+
+This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 License.  To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/3.0/ or send a letter to Creative Commons, 559 Nathan Abbott Way, Stanford, California 94305, USA.
+
+Commercial licenses are also available. To inquire about commercial licenses, please contact Uri Wilensky at uri@northwestern.edu.
+
+<!-- 2016 GenEvo Cite: Dabholkar, S. -->
+@#$#@#$#@
+default
+true
+0
+Polygon -7500403 true true 150 5 40 250 150 205 260 250
+
+airplane
+true
+0
+Polygon -7500403 true true 150 0 135 15 120 60 120 105 15 165 15 195 120 180 135 240 105 270 120 285 150 270 180 285 210 270 165 240 180 180 285 195 285 165 180 105 180 60 165 15
+
+arrow
+true
+0
+Polygon -7500403 true true 150 0 0 150 105 150 105 293 195 293 195 150 300 150
+
+box
+false
+0
+Polygon -7500403 true true 150 285 285 225 285 75 150 135
+Polygon -7500403 true true 150 135 15 75 150 15 285 75
+Polygon -7500403 true true 15 75 15 225 150 285 150 135
+Line -16777216 false 150 285 150 135
+Line -16777216 false 150 135 15 75
+Line -16777216 false 150 135 285 75
+
+bug
+true
+0
+Circle -7500403 true true 96 182 108
+Circle -7500403 true true 110 127 80
+Circle -7500403 true true 110 75 80
+Line -7500403 true 150 100 80 30
+Line -7500403 true 150 100 220 30
+
+butterfly
+true
+0
+Polygon -7500403 true true 150 165 209 199 225 225 225 255 195 270 165 255 150 240
+Polygon -7500403 true true 150 165 89 198 75 225 75 255 105 270 135 255 150 240
+Polygon -7500403 true true 139 148 100 105 55 90 25 90 10 105 10 135 25 180 40 195 85 194 139 163
+Polygon -7500403 true true 162 150 200 105 245 90 275 90 290 105 290 135 275 180 260 195 215 195 162 165
+Polygon -16777216 true false 150 255 135 225 120 150 135 120 150 105 165 120 180 150 165 225
+Circle -16777216 true false 135 90 30
+Line -16777216 false 150 105 195 60
+Line -16777216 false 150 105 105 60
+
+car
+false
+0
+Polygon -7500403 true true 300 180 279 164 261 144 240 135 226 132 213 106 203 84 185 63 159 50 135 50 75 60 0 150 0 165 0 225 300 225 300 180
+Circle -16777216 true false 180 180 90
+Circle -16777216 true false 30 180 90
+Polygon -16777216 true false 162 80 132 78 134 135 209 135 194 105 189 96 180 89
+Circle -7500403 true true 47 195 58
+Circle -7500403 true true 195 195 58
+
+circle
+false
+0
+Circle -7500403 true true 0 0 300
+
+circle 2
+false
+0
+Circle -7500403 true true 0 0 300
+Circle -16777216 true false 30 30 240
+
+cow
+false
+0
+Polygon -7500403 true true 200 193 197 249 179 249 177 196 166 187 140 189 93 191 78 179 72 211 49 209 48 181 37 149 25 120 25 89 45 72 103 84 179 75 198 76 252 64 272 81 293 103 285 121 255 121 242 118 224 167
+Polygon -7500403 true true 73 210 86 251 62 249 48 208
+Polygon -7500403 true true 25 114 16 195 9 204 23 213 25 200 39 123
+
+cylinder
+false
+0
+Circle -7500403 true true 0 0 300
+
+ecoli
+true
+0
+Rectangle -7500403 true true 75 90 225 210
+Circle -7500403 true true 15 90 120
+Circle -7500403 true true 165 90 120
+
+face happy
+false
+0
+Circle -7500403 true true 8 8 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Polygon -16777216 true false 150 255 90 239 62 213 47 191 67 179 90 203 109 218 150 225 192 218 210 203 227 181 251 194 236 217 212 240
+
+face neutral
+false
+0
+Circle -7500403 true true 8 7 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Rectangle -16777216 true false 60 195 240 225
+
+face sad
+false
+0
+Circle -7500403 true true 8 8 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Polygon -16777216 true false 150 168 90 184 62 210 47 232 67 244 90 220 109 205 150 198 192 205 210 220 227 242 251 229 236 206 212 183
+
+fish
+false
+0
+Polygon -1 true false 44 131 21 87 15 86 0 120 15 150 0 180 13 214 20 212 45 166
+Polygon -1 true false 135 195 119 235 95 218 76 210 46 204 60 165
+Polygon -1 true false 75 45 83 77 71 103 86 114 166 78 135 60
+Polygon -7500403 true true 30 136 151 77 226 81 280 119 292 146 292 160 287 170 270 195 195 210 151 212 30 166
+Circle -16777216 true false 215 106 30
+
+flag
+false
+0
+Rectangle -7500403 true true 60 15 75 300
+Polygon -7500403 true true 90 150 270 90 90 30
+Line -7500403 true 75 135 90 135
+Line -7500403 true 75 45 90 45
+
+flower
+false
+0
+Polygon -10899396 true false 135 120 165 165 180 210 180 240 150 300 165 300 195 240 195 195 165 135
+Circle -7500403 true true 85 132 38
+Circle -7500403 true true 130 147 38
+Circle -7500403 true true 192 85 38
+Circle -7500403 true true 85 40 38
+Circle -7500403 true true 177 40 38
+Circle -7500403 true true 177 132 38
+Circle -7500403 true true 70 85 38
+Circle -7500403 true true 130 25 38
+Circle -7500403 true true 96 51 108
+Circle -16777216 true false 113 68 74
+Polygon -10899396 true false 189 233 219 188 249 173 279 188 234 218
+Polygon -10899396 true false 180 255 150 210 105 210 75 240 135 240
+
+house
+false
+0
+Rectangle -7500403 true true 45 120 255 285
+Rectangle -16777216 true false 120 210 180 285
+Polygon -7500403 true true 15 120 150 15 285 120
+Line -16777216 false 30 120 270 120
+
+lactose
+true
+0
+Polygon -7500403 true true 150 135 135 150 135 165 165 165 165 150 150 135
+
+leaf
+false
+0
+Polygon -7500403 true true 150 210 135 195 120 210 60 210 30 195 60 180 60 165 15 135 30 120 15 105 40 104 45 90 60 90 90 105 105 120 120 120 105 60 120 60 135 30 150 15 165 30 180 60 195 60 180 120 195 120 210 105 240 90 255 90 263 104 285 105 270 120 285 135 240 165 240 180 270 195 240 210 180 210 165 195
+Polygon -7500403 true true 135 195 135 240 120 255 105 255 105 285 135 285 165 240 165 195
+
+line
+true
+0
+Line -7500403 true 150 0 150 300
+
+line half
+true
+0
+Line -7500403 true 150 0 150 150
+
+pentagon
+false
+0
+Polygon -7500403 true true 150 15 15 120 60 285 240 285 285 120
+
+person
+false
+0
+Circle -7500403 true true 110 5 80
+Polygon -7500403 true true 105 90 120 195 90 285 105 300 135 300 150 225 165 300 195 300 210 285 180 195 195 90
+Rectangle -7500403 true true 127 79 172 94
+Polygon -7500403 true true 195 90 240 150 225 180 165 105
+Polygon -7500403 true true 105 90 60 150 75 180 135 105
+
+plant
+false
+0
+Rectangle -7500403 true true 135 90 165 300
+Polygon -7500403 true true 135 255 90 210 45 195 75 255 135 285
+Polygon -7500403 true true 165 255 210 210 255 195 225 255 165 285
+Polygon -7500403 true true 135 180 90 135 45 120 75 180 135 210
+Polygon -7500403 true true 165 180 165 210 225 180 255 120 210 135
+Polygon -7500403 true true 135 105 90 60 45 45 75 105 135 135
+Polygon -7500403 true true 165 105 165 135 225 105 255 45 210 60
+Polygon -7500403 true true 135 90 120 45 150 15 180 45 165 90
+
+sheep
+false
+15
+Circle -1 true true 203 65 88
+Circle -1 true true 70 65 162
+Circle -1 true true 150 105 120
+Polygon -7500403 true false 218 120 240 165 255 165 278 120
+Circle -7500403 true false 214 72 67
+Rectangle -1 true true 164 223 179 298
+Polygon -1 true true 45 285 30 285 30 240 15 195 45 210
+Circle -1 true true 3 83 150
+Rectangle -1 true true 65 221 80 296
+Polygon -1 true true 195 285 210 285 210 240 240 210 195 210
+Polygon -7500403 true false 276 85 285 105 302 99 294 83
+Polygon -7500403 true false 219 85 210 105 193 99 201 83
+
+square
+false
+0
+Rectangle -7500403 true true 30 30 270 270
+
+square 2
+false
+0
+Rectangle -7500403 true true 30 30 270 270
+Rectangle -16777216 true false 60 60 240 240
+
+star
+false
+0
+Polygon -7500403 true true 151 1 185 108 298 108 207 175 242 282 151 216 59 282 94 175 3 108 116 108
+
+target
+false
+0
+Circle -7500403 true true 0 0 300
+Circle -16777216 true false 30 30 240
+Circle -7500403 true true 60 60 180
+Circle -16777216 true false 90 90 120
+Circle -7500403 true true 120 120 60
+
+tree
+false
+0
+Circle -7500403 true true 118 3 94
+Rectangle -6459832 true false 120 195 180 300
+Circle -7500403 true true 65 21 108
+Circle -7500403 true true 116 41 127
+Circle -7500403 true true 45 90 120
+Circle -7500403 true true 104 74 152
+
+triangle
+false
+0
+Polygon -7500403 true true 150 30 15 255 285 255
+
+triangle 2
+false
+0
+Polygon -7500403 true true 150 30 15 255 285 255
+Polygon -16777216 true false 151 99 225 223 75 224
+
+truck
+false
+0
+Rectangle -7500403 true true 4 45 195 187
+Polygon -7500403 true true 296 193 296 150 259 134 244 104 208 104 207 194
+Rectangle -1 true false 195 60 195 105
+Polygon -16777216 true false 238 112 252 141 219 141 218 112
+Circle -16777216 true false 234 174 42
+Rectangle -7500403 true true 181 185 214 194
+Circle -16777216 true false 144 174 42
+Circle -16777216 true false 24 174 42
+Circle -7500403 false true 24 174 42
+Circle -7500403 false true 144 174 42
+Circle -7500403 false true 234 174 42
+
+turtle
+true
+0
+Polygon -10899396 true false 215 204 240 233 246 254 228 266 215 252 193 210
+Polygon -10899396 true false 195 90 225 75 245 75 260 89 269 108 261 124 240 105 225 105 210 105
+Polygon -10899396 true false 105 90 75 75 55 75 40 89 31 108 39 124 60 105 75 105 90 105
+Polygon -10899396 true false 132 85 134 64 107 51 108 17 150 2 192 18 192 52 169 65 172 87
+Polygon -10899396 true false 85 204 60 233 54 254 72 266 85 252 107 210
+Polygon -7500403 true true 119 75 179 75 209 101 224 135 220 225 175 261 128 261 81 224 74 135 88 99
+
+wheel
+false
+0
+Circle -7500403 true true 3 3 294
+Circle -16777216 true false 30 30 240
+Line -7500403 true 150 285 150 15
+Line -7500403 true 15 150 285 150
+Circle -7500403 true true 120 120 60
+Line -7500403 true 216 40 79 269
+Line -7500403 true 40 84 269 221
+Line -7500403 true 40 216 269 79
+Line -7500403 true 84 40 221 269
+
+wolf
+false
+0
+Polygon -16777216 true false 253 133 245 131 245 133
+Polygon -7500403 true true 2 194 13 197 30 191 38 193 38 205 20 226 20 257 27 265 38 266 40 260 31 253 31 230 60 206 68 198 75 209 66 228 65 243 82 261 84 268 100 267 103 261 77 239 79 231 100 207 98 196 119 201 143 202 160 195 166 210 172 213 173 238 167 251 160 248 154 265 169 264 178 247 186 240 198 260 200 271 217 271 219 262 207 258 195 230 192 198 210 184 227 164 242 144 259 145 284 151 277 141 293 140 299 134 297 127 273 119 270 105
+Polygon -7500403 true true -1 195 14 180 36 166 40 153 53 140 82 131 134 133 159 126 188 115 227 108 236 102 238 98 268 86 269 92 281 87 269 103 269 113
+
+x
+false
+0
+Polygon -7500403 true true 270 75 225 30 30 225 75 270
+Polygon -7500403 true true 30 75 75 30 270 225 225 270
+@#$#@#$#@
+NetLogo 6.0-M9
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+default
+0.0
+-0.2 0 0.0 1.0
+0.0 1 1.0 0.0
+0.2 0 0.0 1.0
+link direction
+true
+0
+Line -7500403 true 150 150 90 180
+Line -7500403 true 150 150 210 180
+@#$#@#$#@
+1
+@#$#@#$#@

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object MyBuild extends Build {
 
-  lazy val netLogo = ProjectRef(uri("git://github.com/NetLogo/NetLogo.git#6.0.0-M9"), "netlogo")
+  lazy val netLogo = ProjectRef(uri("git://github.com/NetLogo/NetLogo.git"), "netlogo")
 
   lazy val root = Project("root", file("."))
     .dependsOn(netLogo)

--- a/src/main/scala/org/nlogo/models/LegalInfo.scala
+++ b/src/main/scala/org/nlogo/models/LegalInfo.scala
@@ -205,8 +205,8 @@ case class LegalInfo(model: Model) {
       if (keywords.contains("GenEvo")) {
         builder.append("\n")
         builder.append("To cite the GenEvo Systems Biology curriculum as a whole, please use:\n\n")
-        builder.append("* Dabholkar S. & Wilensky, U. (2016). ")
-        builder.append("GenEvo curriculum. ")
+        builder.append("* Dabholkar, S. & Wilensky, U. (2016). ")
+        builder.append("GenEvo Systems Biology curriculum. ")
         builder.append("http://ccl.northwestern.edu/curriculum/genevo/. ")
         builder.append("Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.\n")
       }

--- a/src/main/scala/org/nlogo/models/LegalInfo.scala
+++ b/src/main/scala/org/nlogo/models/LegalInfo.scala
@@ -15,7 +15,7 @@ object LegalInfo {
     """<!-- (\d\d\d\d)( \d\d\d\d)?(( \w+)*)( Cite: .*)? -->""".r
   val validKeywords = List(
     "MIT", "Wilensky", "specialCE", "MAC", "Steiner",
-    "Stroup", "3D", "NIELS", "ConChem", "CC0", "BYSA")
+    "Stroup", "3D", "NIELS", "ConChem", "CC0", "BYSA", "GenEvo")
   val textbookCitation =
     "* Wilensky, U. & Rand, W. (2015). Introduction " +
       "to Agent-Based Modeling: Modeling Natural, Social " +
@@ -200,6 +200,14 @@ case class LegalInfo(model: Model) {
         builder.append("* Wilensky, U., Levy, S. T., & Novak, M. (2004). ")
         builder.append("Connected Chemistry curriculum. ")
         builder.append("http://ccl.northwestern.edu/curriculum/chemistry/. ")
+        builder.append("Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.\n")
+      }
+      if (keywords.contains("GenEvo")) {
+        builder.append("\n")
+        builder.append("To cite the GenEvo Systems Biology curriculum as a whole, please use:\n\n")
+        builder.append("* Dabholkar S. & Wilensky, U. (2016). ")
+        builder.append("GenEvo curriculum. ")
+        builder.append("http://ccl.northwestern.edu/curriculum/genevo/. ")
         builder.append("Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.\n")
       }
     }

--- a/src/main/scala/org/nlogo/models/LegalInfo.scala
+++ b/src/main/scala/org/nlogo/models/LegalInfo.scala
@@ -15,7 +15,7 @@ object LegalInfo {
     """<!-- (\d\d\d\d)( \d\d\d\d)?(( \w+)*)( Cite: .*)? -->""".r
   val validKeywords = List(
     "MIT", "Wilensky", "specialCE", "MAC", "Steiner",
-    "Stroup", "3D", "NIELS", "ConChem", "CC0", "BYSA", "GenEvo", "LatticeLand")
+    "Stroup", "3D", "NIELS", "ConChem", "CC0", "BYSA", "GenEvo")
   val textbookCitation =
     "* Wilensky, U. & Rand, W. (2015). Introduction " +
       "to Agent-Based Modeling: Modeling Natural, Social " +
@@ -205,17 +205,9 @@ case class LegalInfo(model: Model) {
       if (keywords.contains("GenEvo")) {
         builder.append("\n")
         builder.append("To cite the GenEvo Systems Biology curriculum as a whole, please use:\n\n")
-        builder.append("* Dabholkar, S. & Wilensky, U. (2016). ")
+        builder.append("* Dabholkar S. & Wilensky, U. (2016). ")
         builder.append("GenEvo curriculum. ")
         builder.append("http://ccl.northwestern.edu/curriculum/genevo/. ")
-        builder.append("Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.\n")
-      }
-      if (keywords.contains("LatticeLand")) {
-        builder.append("\n")
-        builder.append("To cite the Lattice Land curriculum as a whole, please use:\n\n")
-        builder.append("* Pei, C. & Wilensky, U. (2016). ")
-        builder.append("Lattice Land curriculum. ")
-        builder.append("http://ccl.northwestern.edu/curriculum/latticeland/. ")
         builder.append("Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.\n")
       }
     }

--- a/src/main/scala/org/nlogo/models/LegalInfo.scala
+++ b/src/main/scala/org/nlogo/models/LegalInfo.scala
@@ -15,7 +15,7 @@ object LegalInfo {
     """<!-- (\d\d\d\d)( \d\d\d\d)?(( \w+)*)( Cite: .*)? -->""".r
   val validKeywords = List(
     "MIT", "Wilensky", "specialCE", "MAC", "Steiner",
-    "Stroup", "3D", "NIELS", "ConChem", "CC0", "BYSA", "GenEvo")
+    "Stroup", "3D", "NIELS", "ConChem", "CC0", "BYSA", "GenEvo", "LatticeLand")
   val textbookCitation =
     "* Wilensky, U. & Rand, W. (2015). Introduction " +
       "to Agent-Based Modeling: Modeling Natural, Social " +
@@ -205,9 +205,17 @@ case class LegalInfo(model: Model) {
       if (keywords.contains("GenEvo")) {
         builder.append("\n")
         builder.append("To cite the GenEvo Systems Biology curriculum as a whole, please use:\n\n")
-        builder.append("* Dabholkar S. & Wilensky, U. (2016). ")
+        builder.append("* Dabholkar, S. & Wilensky, U. (2016). ")
         builder.append("GenEvo curriculum. ")
         builder.append("http://ccl.northwestern.edu/curriculum/genevo/. ")
+        builder.append("Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.\n")
+      }
+      if (keywords.contains("LatticeLand")) {
+        builder.append("\n")
+        builder.append("To cite the Lattice Land curriculum as a whole, please use:\n\n")
+        builder.append("* Pei, C. & Wilensky, U. (2016). ")
+        builder.append("Lattice Land curriculum. ")
+        builder.append("http://ccl.northwestern.edu/curriculum/latticeland/. ")
         builder.append("Center for Connected Learning and Computer-Based Modeling, Northwestern University, Evanston, IL.\n")
       }
     }

--- a/src/test/resources/modelwords.txt
+++ b/src/test/resources/modelwords.txt
@@ -239,6 +239,7 @@ backticks
 badcollisions
 baed
 Baer
+Bain
 Bak
 Bak's
 Bakshy
@@ -751,6 +752,7 @@ D'Andria's
 d'economia
 dA
 da
+Dabholkar
 Dahm
 Daisyworld
 daisyworld

--- a/src/test/resources/modelwords.txt
+++ b/src/test/resources/modelwords.txt
@@ -1000,6 +1000,7 @@ Eberhart's
 Ebola
 EColi
 ecoli
+ecolis
 ecologies
 econophysics
 econophysics
@@ -1054,6 +1055,7 @@ env
 EnzymeKinetics
 epicycloid
 epiDEM
+epigenetic
 EPS
 Epstein's
 eq
@@ -1255,6 +1257,7 @@ Gagandeep
 gagands
 Gaia
 Gainesville
+galactosidase
 Galton
 galton
 GaltonBox
@@ -1298,6 +1301,7 @@ GenDriftPglobal
 GenDriftPlocal
 GenDriftTinteract
 GenDriftTreproduce
+GenEvo
 genome
 genomes
 genotype
@@ -1773,6 +1777,15 @@ Ku
 Kunihiko
 kx
 ky
+lacI
+LACI
+lacIs
+lacY
+lacYs
+lacZ
+LACZ
+lacZs
+lactoses
 Lairson
 Lamarckian
 Lambert
@@ -1809,6 +1822,7 @@ Lett
 Leu
 leu
 leve
+LevelSpace
 level's
 Levin
 lf
@@ -2054,6 +2068,7 @@ mnrch
 mnrchs
 Mny
 modcharge
+modelled
 Modelling
 ModelSim
 modiforce
@@ -2402,6 +2417,7 @@ one's
 Online
 online
 onn
+ONPG
 onramp
 OOI
 ooi
@@ -2411,6 +2427,8 @@ ooo
 op
 openWeek
 operacoes
+operon
+Operon
 OPITCH
 opitch
 oppposite
@@ -2553,6 +2571,8 @@ perimeters
 perm
 PERMEABILITY
 permeability
+permease
+permeases
 PERMI
 permi
 PERMIS
@@ -2874,6 +2894,7 @@ Replot
 reposition
 REPP
 repr
+repressor
 reproductively
 repuzzlefy
 reradiated
@@ -2910,6 +2931,7 @@ RGBA
 rht
 ribose
 ribosome
+ribosomes
 Righties
 righties
 rightparenth
@@ -2923,6 +2945,8 @@ riverbed
 rmult
 rn
 rnd
+RNAP
+RNAPs
 Ro
 ro
 robby

--- a/src/test/scala/org/nlogo/models/CodeTests.scala
+++ b/src/test/scala/org/nlogo/models/CodeTests.scala
@@ -229,6 +229,7 @@ class CodeTests extends TestModels {
       "ZPD"
    ),
    "GenEvo 1 Genetic Switch" -> Set(
+     "go-lacY", "lacI", "lacZs", "lacIs-own", "create-RNAPs", "RNAP", "on-DNA?",
      "lacZ-production-num", "lacYs", "lacZ-production-cost",
      "LevelSpace?", "lacY-degradation-chance", "lacI-number",
      "create-lacIs", "RNAPs-own", "lacZ", "go-lacI",

--- a/src/test/scala/org/nlogo/models/CodeTests.scala
+++ b/src/test/scala/org/nlogo/models/CodeTests.scala
@@ -227,7 +227,21 @@ class CodeTests extends TestModels {
     ),
     "Piaget-Vygotsky Game" -> Set(
       "ZPD"
-    )
+   ),
+   "GenEvo 1 Genetic Switch" -> Set(
+     "lacZ-production-num", "lacYs", "lacZ-production-cost",
+     "LevelSpace?", "lacY-degradation-chance", "lacI-number",
+     "create-lacIs", "RNAPs-own", "lacZ", "go-lacI",
+     "lacI-bond-leakage", "go-lacZ", "lacI-lactose-binding-chance",
+     "RNAP-number", "lacI-lactose-binding-chance", "lacY-production-num",
+     "lacI-bond-leakage", "hatch-lacYs", "lacY", "lacIs",
+     "lacI-lactose-separation-chance", "hatch-lacZs", "RNAPs", "go-RNAP",
+     "lacY-production-cost", "lacZ-degradation-chance", "lacI-lactose-separation-chance",
+     "create-lacZs", "create-lacYs", "go-lacZ", "lacZs", "lacI-number", "lacY-degradation-chance"
+   ),
+   "GenEvo 4 Competition" -> Set(
+     "LevelSpace?", "lacZ-inside", "lacI-lactose-complex", "lacY-inserted", "lacY-inside"
+  )
   )
 
   val typesToCheck = Set[TokenType](


### PR DESCRIPTION
Adds GenEvo 1-4 to the Models library under `Curricular Models/GenEvo`.

Updates the `sbt` tests to allow for these models. (Note: Tests (ButtonTest and CompilationTest) will fail until `ls` is bundled into NetLogo)

Adds GenEvo keyword to LegalInfo for Notarizer (c07cd90).
