### PR TITLE
Tests: fetch head of default NetLogo branch instead of specific tag

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object MyBuild extends Build {
 
-  lazy val netLogo = ProjectRef(uri("git://github.com/NetLogo/NetLogo.git#6.0.0-M9"), "netlogo")
+  lazy val netLogo = ProjectRef(uri("git://github.com/NetLogo/NetLogo.git"), "netlogo")
 
   lazy val root = Project("root", file("."))
     .dependsOn(netLogo)


### PR DESCRIPTION
This is meant to close #280.

It seems like leaving the name of the branch unspecified when fetching NetLogo from GitHub gets around the problem described in #280.