### PR TITLE
Algae: fixes

### DIFF
--- a/Sample Models/Biology/Unverified/Algae.nlogo
+++ b/Sample Models/Biology/Unverified/Algae.nlogo
@@ -33,7 +33,7 @@ to setup-globals
 end
 
 to setup-environment
-  set day-length 12
+  if change-day-length? [ set day-length 12 ]
   ask air [ set light 1 ]
   ask ground [ set light 0 ]
   ask water [ set light 0 ]
@@ -86,13 +86,13 @@ end
 
 to go
   if not any? algae [ stop ]
-  ;; 24 hour days
-  let day ticks / 24
-  ;; assume all months are the same length
-  let month day / 10
-  ;; day length cycles up and down based on the time of year
   if change-day-length? [
-    set day-length precision (12 + 4 * sin ( month * 180 / 12 )) 2
+    ;; 24 hour days
+    let day ticks / 24
+    ;; assume all months are the same length
+    let month day / 10
+    ;; day length cycles up and down based on the time of year
+    set day-length precision (12 + 4 * sin (month * 180 / 12)) 2
   ]
   if day-and-night? [
     spread-light
@@ -307,7 +307,7 @@ day-length
 day-length
 8
 16
-12.79
+12.0
 0.1
 1
 hours
@@ -336,20 +336,20 @@ day-and-night?
 -1000
 
 TEXTBOX
-209
-503
-313
-531
+205
+510
+330
+530
 light hours per 24
 11
 0.0
 0
 
 TEXTBOX
-207
+205
 415
-334
-462
+331
+445
 change light\nthroughout the day
 11
 0.0
@@ -357,9 +357,9 @@ change light\nthroughout the day
 
 TEXTBOX
 205
-460
+455
 330
-502
+490
 change duration of\nlight from day to day
 11
 0.0
@@ -753,5 +753,5 @@ true
 Line -7500403 true 150 150 90 180
 Line -7500403 true 150 150 210 180
 @#$#@#$#@
-0
+1
 @#$#@#$#@

--- a/Sample Models/Biology/Unverified/Algae.nlogo
+++ b/Sample Models/Biology/Unverified/Algae.nlogo
@@ -33,6 +33,7 @@ to setup-globals
 end
 
 to setup-environment
+  set day-length 12
   ask air [ set light 1 ]
   ask ground [ set light 0 ]
   ask water [ set light 0 ]
@@ -91,7 +92,7 @@ to go
   let month day / 10
   ;; day length cycles up and down based on the time of year
   if change-day-length? [
-    set day-length 12 + 4 * sin ( month * 180 / 12 )
+    set day-length precision (12 + 4 * sin ( month * 180 / 12 )) 2
   ]
   if day-and-night? [
     spread-light
@@ -298,15 +299,15 @@ PENS
 "default" 1.0 1 -16777216 true "" "histogram [ ycor ] of algae"
 
 SLIDER
-14
-500
-197
-533
+15
+502
+199
+535
 day-length
 day-length
 8
 16
-12.143958568001993
+12.79
 0.1
 1
 hours
@@ -335,9 +336,9 @@ day-and-night?
 -1000
 
 TEXTBOX
-205
-504
-322
+209
+503
+313
 531
 light hours per 24
 11


### PR DESCRIPTION
- adjust day length on setup when change-day-length? is on
- use 2 digits of precision for day length