### PR TITLE
Upgrade pegdown to flexmark, Fix #341

### DIFF
--- a/Code Examples/Info Tab Example.nlogo
+++ b/Code Examples/Info Tab Example.nlogo
@@ -400,7 +400,7 @@ We have tested the features shown above on a variety of systems.  If you use oth
 
 If you want all NetLogo users to be able to read your Info tab, use only the features shown above.
 
-More information about Markdown is at http://daringfireball.net/projects/markdown/. For rendering Markdown, NetLogo uses the [Pegdown](https://github.com/sirthias/pegdown) library.
+More information about Markdown is at http://daringfireball.net/projects/markdown/. For rendering Markdown, NetLogo uses the [Flexmark-java](https://github.com/vsch/flexmark-java) library.
 
 [netlogo-link]: http://ccl.northwestern.edu/netlogo
 

--- a/Code Examples/Info Tab Example.nlogo
+++ b/Code Examples/Info Tab Example.nlogo
@@ -132,6 +132,7 @@ We are about to start an ordered list.
     1. Subitems are indented 2 more spaces (4 in all).
   2. The next item in the list starts with the next number.
   3. And so on...
+```
 
 #### Formatted
 
@@ -153,6 +154,7 @@ We are about to start an unordered list.
   * Unlike ordered lists, unordered lists use stars instead of numbers.
     * Sub items are indented 2 more spaces.
     * Here's another sub item.
+```
 
 #### Formatted
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,10 @@ libraryDependencies ++= Seq(
   "org.asynchttpclient" % "async-http-client" % "2.0.24",
   "com.github.wookietreiber" %% "scala-chart" % "0.5.1",
   "com.googlecode.java-diff-utils" % "diffutils" % "1.2" % "test",
-  "org.jfree" % "jfreesvg" % "3.0"
+  "org.jfree" % "jfreesvg" % "3.0",
+  "com.vladsch.flexmark" % "flexmark" % "0.20.0" % "test",
+  "com.vladsch.flexmark" % "flexmark-ext-autolink" % "0.20.0" % "test",
+  "com.vladsch.flexmark" % "flexmark-util" % "0.20.0" % "test"
 )
 
 (test in Test) <<= (test in Test) dependsOn {


### PR DESCRIPTION
Fixes #341 

+ Converts Library tests from pegdown to Flexmark
+ Updates reference to markdown library in Info Tab Example model
+ Fixes indentation syntax in Info Tab Example resulting from migration
+ Fixes code fencing issue in Info Tab Example Model

All courtesy of @mrerrormessage. 