### PR TITLE
Fireworks: Change `fireworks` to `max-fireworks`, Fix #340

### DIFF
--- a/Sample Models/Art/Fireworks.nlogo
+++ b/Sample Models/Art/Fireworks.nlogo
@@ -49,7 +49,7 @@ end
 ; slider FIREWORKS and sets all the initial values for each firework.
 to init-rockets
   clear-drawing
-  create-rockets (random fireworks) [
+  create-rockets (random max-fireworks) + 1 [
     setxy random-xcor min-pycor
     set x-vel ((random-float (2 * initial-x-vel)) - (initial-x-vel))
     set y-vel ((random-float initial-y-vel) + initial-y-vel * 2)
@@ -183,8 +183,8 @@ SLIDER
 38
 232
 71
-fireworks
-fireworks
+max-fireworks
+max-fireworks
 1
 40
 20.0

--- a/Sample Models/Art/Fireworks.nlogo
+++ b/Sample Models/Art/Fireworks.nlogo
@@ -632,7 +632,7 @@ Polygon -7500403 true true 30 75 75 30 270 225 225 270
 NetLogo 6.0.1
 @#$#@#$#@
 set trails? true
-set fireworks 30
+set max-fireworks 30
 random-seed 3
 setup
 repeat 50 [ go ]


### PR DESCRIPTION
In order to fix #340, it seems the best change is to rename the `fireworks` parameter. The original model selects a random number of fireworks between [0, `fireworks`). This means that with `fireworks = 1`, there are no fireworks and at any value of `fireworks` you can have a round with 0 fireworks.

This update addresses those two things by:

1. Rename `fireworks` to `max-fireworks`. Because of the randomness selected by the model author, this more accurately conveys to the user why they may not see exactly the number of `fireworks` go off that they selected.

2. Enforce a strict minimum of 1 firework (by using `(random max-fireworks) + 1`. This also means that when you select a `max-fireworks` of 18, you can actually see 18 fireworks. In the previous version, you would see at most 17.

As such, this PR fixes #340.