### PR TITLE
Redo cross-referencing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ target/
 /test/applet/NetLogo.jar
 /test/applet/NetLogoLite.jar
 /test/benchmarks/firebig*.csv
-/index.txt
+/index.conf
 /Alternative Visualizations/Ethnocentrism - Alternative Visualization.png
 /Alternative Visualizations/Flocking - Alternative Visualizations.png
 /Alternative Visualizations/Heat Diffusion - Alternative Visualization.png

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ libraryDependencies ++= Seq(
   "com.github.wookietreiber" %% "scala-chart" % "0.5.1",
   "com.googlecode.java-diff-utils" % "diffutils" % "1.2" % "test",
   "org.jfree" % "jfreesvg" % "3.0",
+  "com.typesafe" % "config" % "1.3.1" % "test",
   "com.vladsch.flexmark" % "flexmark" % "0.20.0" % "test",
   "com.vladsch.flexmark" % "flexmark-ext-autolink" % "0.20.0" % "test",
   "com.vladsch.flexmark" % "flexmark-util" % "0.20.0" % "test"

--- a/crossReference.conf
+++ b/crossReference.conf
@@ -1,0 +1,55 @@
+org.nlogo.models.crossReference.singleModels: [
+  { source: "Sample Models/Biology/AIDS.nlogo",               referenceIn: "Sample Models/Social Science" }
+  { source: "Sample Models/Biology/Simple Birth Rates.nlogo", referenceIn: "Sample Models/Social Science" }
+
+  { source: "Sample Models/Biology/Evolution/Altruism.nlogo",    referenceIn: "Sample Models/Social Science" }
+  { source: "Sample Models/Biology/Evolution/Cooperation.nlogo", referenceIn: "Sample Models/Social Science" }
+
+  { source: "Sample Models/Biology/Evolution/Unverified/Divide The Cake.nlogo",
+     referenceIn: "Sample Models/Social Science/Unverified" }
+
+  { source: "Sample Models/Biology/Evolution/Altruism.nlogo",    referenceIn: "Curricular Models/EACH" }
+  { source: "Sample Models/Biology/Evolution/Cooperation.nlogo", referenceIn: "Curricular Models/EACH" }
+
+  { source: "Sample Models/Biology/Evolution/Unverified/Divide The Cake.nlogo",
+     referenceIn: "Curricular Models/EACH/Unverified" }
+
+  { source: "Sample Models/Networks/Team Assembly.nlogo",      referenceIn: "Sample Models/Social Science" }
+
+  { source: "Code Examples/Extensions Examples/vid/Video Camera Example.nlogo", referenceIn: "Code Examples/Extension Examples/bitmap" }
+
+  // BEAGLE curricular models
+  { source: "Sample Models/Biology/Wolf Sheep Predation.nlogo",                        referenceIn: "Curricular Models/BEAGLE Evolution" }
+  { source: "Sample Models/Biology/Evolution/Genetic Drift/GenDrift T interact.nlogo", referenceIn: "Curricular Models/BEAGLE Evolution" }
+  { source: "Sample Models/Biology/Evolution/Bug Hunt Speeds.nlogo",                   referenceIn: "Curricular Models/BEAGLE Evolution" }
+  { source: "Sample Models/Biology/Evolution/Bug Hunt Camouflage.nlogo",               referenceIn: "Curricular Models/BEAGLE Evolution" }
+  { source: "HubNet Activities/Unverified/Guppy Spots HubNet.nlogo",                   referenceIn: "Curricular Models/BEAGLE Evolution" }
+  { source: "Sample Models/Biology/Daisyworld.nlogo",                                  referenceIn: "Curricular Models/BEAGLE Evolution" }
+  { source: "Sample Models/Biology/Evolution/Mimicry.nlogo",                           referenceIn: "Curricular Models/BEAGLE Evolution" }
+  { source: "Sample Models/Biology/Evolution/Altruism.nlogo",                          referenceIn: "Curricular Models/BEAGLE Evolution" }
+  { source: "Sample Models/Biology/Evolution/Cooperation.nlogo",                       referenceIn: "Curricular Models/BEAGLE Evolution" }
+  { source: "HubNet Activities/Bug Hunters Camouflage HubNet.nlogo", referenceIn: "Curricular Models/BEAGLE Evolution/HubNet Activities" }
+
+  // copy BEAGLE HubNet models to hubnet activities
+  { source: "Curricular Models/BEAGLE Evolution/HubNet Activities/Bird Breeders HubNet.nlogo",           referenceIn: "HubNet Activities" }
+  { source: "Curricular Models/BEAGLE Evolution/HubNet Activities/Bug Hunters Competition HubNet.nlogo", referenceIn: "HubNet Activities" }
+  { source: "Curricular Models/BEAGLE Evolution/HubNet Activities/Critter Designers HubNet.nlogo",       referenceIn: "HubNet Activities" }
+  { source: "Curricular Models/BEAGLE Evolution/HubNet Activities/Fish Spotters HubNet.nlogo",           referenceIn: "HubNet Activities" }
+
+  // Oil Cartel HubNet to HubNet Activities
+  { source: "Sample Models/Social Science/Oil Cartel HubNet.nlogo", referenceIn: "HubNet Activities" }
+
+  // IABM Textbook models duplicated in Sample Models and Code Examples
+  { source: "IABM Textbook/chapter 3/El Farol Extensions/El Farol.nlogo",  referenceIn: "Sample Models/Social Science" }
+  { source: "IABM Textbook/chapter 3/DLA extensions/DLA Simple.nlogo",     referenceIn: "Sample Models/Chemistry & Physics/Diffusion Limited Aggregation" }
+  { source: "IABM Textbook/chapter 8/Arduino Example.nlogo",               referenceIn: "Code Examples/Extensions Examples/arduino" }
+]
+
+org.nlogo.models.crossReference.directories: [
+  { sourceDir: "Sample Models/Mathematics/Probability/ProbLab", referenceIn: "Curricular Models/ProbLab", recursive: false }
+  { sourceDir: "Sample Models/Mathematics/Probability/ProbLab/Unverified",
+    referenceIn: "Curricular Models/ProbLab", recursive: false }
+
+  { sourceDir: "Sample Models/Chemistry & Physics/GasLab", referenceIn: "Curricular Models/GasLab", recursive: true }
+  { sourceDir: "Sample Models/Chemistry & Physics/MaterialSim", referenceIn: "Curricular Models/MaterialSim", recursive: true }
+]

--- a/crossReference.conf
+++ b/crossReference.conf
@@ -41,7 +41,7 @@ org.nlogo.models.crossReference.singleModels: [
 
   // IABM Textbook models duplicated in Sample Models and Code Examples
   { source: "IABM Textbook/chapter 3/El Farol Extensions/El Farol.nlogo",  referenceIn: "Sample Models/Social Science" }
-  { source: "IABM Textbook/chapter 3/DLA extensions/DLA Simple.nlogo",     referenceIn: "Sample Models/Chemistry & Physics/Diffusion Limited Aggregation" }
+  { source: "IABM Textbook/chapter 3/DLA Extensions/DLA Simple.nlogo",     referenceIn: "Sample Models/Chemistry & Physics/Diffusion Limited Aggregation" }
   { source: "IABM Textbook/chapter 8/Arduino Example.nlogo",               referenceIn: "Code Examples/Extensions Examples/arduino" }
 ]
 

--- a/src/test/scala/org/nlogo/models/CrossReferenceTests.scala
+++ b/src/test/scala/org/nlogo/models/CrossReferenceTests.scala
@@ -1,0 +1,31 @@
+package org.nlogo.models
+
+import java.io.File
+import java.nio.file.{ Files, Paths }
+
+import com.typesafe.config.{ Config, ConfigFactory }
+
+import org.scalatest.FunSuite
+
+import scala.collection.JavaConverters._
+
+class CrossReferenceTests extends FunSuite {
+
+  val crossReference = ConfigFactory.parseFile(new File("crossReference.conf"))
+
+  test("all cross-referenced single models exist") {
+    val modelRefs = crossReference.getConfigList("org.nlogo.models.crossReference.singleModels").asScala
+    modelRefs.foreach { ref =>
+      val source = ref.getString("source")
+      assert(Files.isRegularFile(Paths.get(source)), s"expected to find a nlogo file at $source, but couldn't find it!")
+    }
+  }
+
+  test("all cross-referenced directories exist and are directories") {
+    val directoryRefs = crossReference.getConfigList("org.nlogo.models.crossReference.directories").asScala
+    directoryRefs.foreach { ref =>
+      val source = ref.getString("sourceDir")
+      assert(Files.isDirectory(Paths.get(source)), s"expected find a directory at $source, but couldn't find it!")
+    }
+  }
+}

--- a/src/test/scala/org/nlogo/models/CrossReferenceTests.scala
+++ b/src/test/scala/org/nlogo/models/CrossReferenceTests.scala
@@ -17,7 +17,14 @@ class CrossReferenceTests extends FunSuite {
     val modelRefs = crossReference.getConfigList("org.nlogo.models.crossReference.singleModels").asScala
     modelRefs.foreach { ref =>
       val source = ref.getString("source")
-      assert(Files.isRegularFile(Paths.get(source)), s"expected to find a nlogo file at $source, but couldn't find it!")
+      val path = Paths.get(source)
+      val realPath = path.toRealPath()
+      val realSubpath =
+        realPath.subpath(realPath.getNameCount - path.getNameCount, realPath.getNameCount)
+      assert(
+        Files.exists(path) && Files.isRegularFile(path) &&
+        realSubpath.toString == path.toString,
+        s"expected to find a nlogo file at $source, but couldn't find it!")
     }
   }
 
@@ -25,7 +32,14 @@ class CrossReferenceTests extends FunSuite {
     val directoryRefs = crossReference.getConfigList("org.nlogo.models.crossReference.directories").asScala
     directoryRefs.foreach { ref =>
       val source = ref.getString("sourceDir")
-      assert(Files.isDirectory(Paths.get(source)), s"expected find a directory at $source, but couldn't find it!")
+      val path = Paths.get(source)
+      val realPath = path.toRealPath()
+      val realSubpath =
+        realPath.subpath(realPath.getNameCount - path.getNameCount, realPath.getNameCount)
+      assert(
+        Files.exists(path) && Files.isDirectory(path) &&
+        realSubpath.toString == path.toString,
+        s"expected find a directory at $source, but couldn't find it!")
     }
   }
 }


### PR DESCRIPTION
@nicolaspayette , @bainco , in order to simplify and speed the build process, I'm changing the way NetLogo performs model cross-referencing. I've done this by adding a file `crossReference.conf` in the root of the models directory which defines all of the paths which are referenced. These virtual paths will be displayed in the Models Library dialog but will not be created on the file system at any point. This should let us remove a massive section of the gitignore (though I haven't done that yet) and avoid copying files all over the place when building the models library. Additionally, adding cross references to the models library no longer requires changes to the NetLogo project. Finally, we no longer have to copy around auxiliary (non-.nlogo/.nlogo3d) files for model preview images and models which require external files.

Things I would like feedback on:

1. Does the format of `crossReference.conf` make sense? It's possible (and fairly easy) to change it now. This could mean changing names, conventions, or even the shape of the file. The syntax used is the fairly-flexible [HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md) which is sort of like JSON + java properties, but writable by human beings.
2. Would you prefer that `crossReference.conf` live somewhere else? It *could* live in the NetLogo project or in a subdirectory of the models project (NetLogo could copy it to the root when it needs it).
3. Would you like documentation about `crossReference.conf` added anywhere in the models project and/or a wiki? 

The other (minor) change here is that I've made the index.txt file an ".conf" file as well. It's still generated by NetLogo. 