### PR TITLE
Updates for variadic `ifelse` and `ifelse-value`

### DIFF
--- a/Code Examples/Extensions Examples/nw/NW General Examples.nlogo
+++ b/Code Examples/Extensions Examples/nw/NW General Examples.nlogo
@@ -22,7 +22,7 @@ end
 
 ;; Reports the link set corresponding to the value of the links-to-use combo box
 to-report get-links-to-use
-  report ifelse-value (links-to-use = "directed")
+  report ifelse-value links-to-use = "directed"
     [ directed-edges ]
     [ undirected-edges ]
 end

--- a/Code Examples/Extensions Examples/sound/Beatbox.nlogo
+++ b/Code Examples/Extensions Examples/sound/Beatbox.nlogo
@@ -126,7 +126,7 @@ end
 to toggle  ;; patch procedure
   if pycor != max-pycor [
     ifelse pxcor = min-pxcor
-      [ set pcolor ifelse-value (pcolor = black) [white] [black] ]
+      [ set pcolor ifelse-value pcolor = black [white] [black] ]
       [ ifelse any? notes-here
           [ ask notes-here [ die ] ]
           [ sprout-notes 1 ] ] ]

--- a/Code Examples/HSB and RGB Example.nlogo
+++ b/Code Examples/HSB and RGB Example.nlogo
@@ -20,8 +20,8 @@ to-report quadrant [x y]  ;; inputs are 1 or -1
 end
 
 to-report patch-quadrant  ;; patch procedure
-  report list ifelse-value (pxcor < world-width / 2) [-1] [1]
-              ifelse-value (pycor < world-width / 2) [-1] [1]
+  report list ifelse-value pxcor < world-width / 2 [-1] [1]
+              ifelse-value pycor < world-width / 2 [-1] [1]
 end
 
 

--- a/Curricular Models/BEAGLE Evolution/DNA Protein Synthesis.nlogo
+++ b/Curricular Models/BEAGLE Evolution/DNA Protein Synthesis.nlogo
@@ -848,7 +848,7 @@ end
 
 
 to-report current-instruction-label
-  report ifelse-value (current-instruction = 0)
+  report ifelse-value current-instruction = 0
     [ "press setup" ]
     [ (word current-instruction " of " length instructions) ]
 end

--- a/Curricular Models/BEAGLE Evolution/DNA Replication Fork.nlogo
+++ b/Curricular Models/BEAGLE Evolution/DNA Replication Fork.nlogo
@@ -756,7 +756,7 @@ end
 
 
 to-report current-instruction-label
-  report ifelse-value (current-instruction = 0)
+  report ifelse-value current-instruction = 0
     [ "press setup" ]
     [ (word current-instruction " / " length instructions) ]
 end

--- a/Curricular Models/GenEvo/GenEvo 1 Genetic Switch.nlogo
+++ b/Curricular Models/GenEvo/GenEvo 1 Genetic Switch.nlogo
@@ -239,7 +239,7 @@ end
 ; procedure for movement and molecular interactions of RNAPs
 to go-RNAPs
   ; In the presence of glucose, the probability of trancription is less.
-  let transcription-probability ifelse-value (glucose?) [ 0.1 ] [ 1 ]
+  let transcription-probability ifelse-value glucose? [ 0.1 ] [ 1 ]
 
   ; If any RNAPs are close to the promoter and the operator is not inhibited
   if (not inhibited?) [

--- a/Curricular Models/Lattice Land/Lattice Land - Explore.nlogo
+++ b/Curricular Models/Lattice Land/Lattice Land - Explore.nlogo
@@ -263,7 +263,7 @@ end
 to-report edges-helper [ vertices-list end-list ]
   let vertex (first vertices-list)
   let tail (but-first vertices-list)
-  report ifelse-value (empty? tail) [ end-list ] [ edges-helper tail (lput ([link-with (first tail)] of vertex) end-list) ]
+  report ifelse-value empty? tail [ end-list ] [ edges-helper tail (lput ([link-with (first tail)] of vertex) end-list) ]
 end
 
 ;  Polygonality code: Checks all edges and its intersections with other edges. In order to be a polygon, each edge must intersect with exactly two other edges.
@@ -339,7 +339,7 @@ to-report shared-link-ends [a b]
   let a-ends [ (list end1 end2) ] of a
   let b-ends [ (list end1 end2) ] of b
   let shared-ends filter [ a-end -> member? a-end b-ends ] a-ends
-  report ifelse-value (empty? shared-ends) [
+  report ifelse-value empty? shared-ends [
     (list)
   ] [
     (list (first shared-ends) (first shared-ends))

--- a/Curricular Models/ModelSim/Evolution/Bacteria Food Hunt.nlogo
+++ b/Curricular Models/ModelSim/Evolution/Bacteria Food Hunt.nlogo
@@ -448,7 +448,7 @@ to visualize-bacteria
     ;; the bacterium appears to be filled with different amounts of "fuel", using different shapes, based on the bacterium's energy level
     set shape word "bacteria-" energy-level
     set label-color black
-    set label ifelse-value (visualize-variation = "# flagella as label") [ word variation "   " ] [ "" ]
+    set label ifelse-value visualize-variation = "# flagella as label" [ word variation "   " ] [ "" ]
   ]
 end
 

--- a/Curricular Models/NIELS/Current in a Wire HubNet.nlogo
+++ b/Curricular Models/NIELS/Current in a Wire HubNet.nlogo
@@ -306,7 +306,7 @@ to update-my-slice-label ; student procedure
 
   ; either display a user-name or a slice #
   let short-name substring user-name 0
-    ifelse-value ((round (slice-width / 4) + 1) > length user-name)
+    ifelse-value (round (slice-width / 4) + 1) > length user-name
       [ length user-name ]
       [ (round (slice-width / 4) + 1) ]
 
@@ -450,7 +450,7 @@ to initialize-hubnet-client ; turtle procedure
 
   ; Send the new interface options to the client
   hubnet-clear-overrides user-name
-  hubnet-send-follow user-name self ifelse-value (18 > (round (abs(left-bound - right-bound)) / 2)) [18] [ (round (abs(left-bound - right-bound)) / 2) ]
+  hubnet-send-follow user-name self ifelse-value 18 > (round (abs(left-bound - right-bound)) / 2) [18] [ (round (abs(left-bound - right-bound)) / 2) ]
   hubnet-send-override user-name (nuclei-on my-patches) "color" [ [color] of myself ]
   hubnet-send user-name "slice" (word "#" slice-id)
 end

--- a/Curricular Models/ProbLab/4 Block Stalagmites.nlogo
+++ b/Curricular Models/ProbLab/4 Block Stalagmites.nlogo
@@ -137,7 +137,7 @@ to make-a-sample-organizer ; sample-dudes procedure
   hatch-sample-organizers 1 [
     hide-turtle
     set sample-values map [ the-sample-dude ->
-      ifelse-value ([ color ] of the-sample-dude = target-color) [ 1 ] [ 0 ]
+      ifelse-value [ color ] of the-sample-dude = target-color [ 1 ] [ 0 ]
     ] sorted-sample-dudes
     display-sample
   ]

--- a/Curricular Models/ProbLab/4 Block Two Stalagmites.nlogo
+++ b/Curricular Models/ProbLab/4 Block Two Stalagmites.nlogo
@@ -162,7 +162,7 @@ to make-a-sample-organizer ; sample-dudes procedure
   hatch-sample-organizers 1 [
     hide-turtle
     set sample-values map [ the-sample-dude ->
-      ifelse-value ([ color ] of the-sample-dude = target-color) [ 1 ] [ 0 ]
+      ifelse-value [ color ] of the-sample-dude = target-color [ 1 ] [ 0 ]
     ] sorted-sample-dudes
     display-sample
     set heading 180
@@ -508,7 +508,7 @@ to-report calculate-left-sample-summary-value
     (([pycor] of sample-dude-1 > [pycor] of sample-dude-2))
   ] left-sample-dudes
   let left-sample-values map [ the-sample-dude ->
-    ifelse-value ([color] of the-sample-dude = target-color) [1] [0]
+    ifelse-value [color] of the-sample-dude = target-color [1] [0]
   ] sorted-left-sample-dudes
   let result 0
   let power-of-two 3

--- a/Curricular Models/ProbLab/4 Blocks.nlogo
+++ b/Curricular Models/ProbLab/4 Blocks.nlogo
@@ -83,7 +83,7 @@ to-report choose [n c]
 end
 
 to-report factorial [n]
-  report ifelse-value (n = 0) [
+  report ifelse-value n = 0 [
     1
   ] [
     n * factorial (n - 1)

--- a/Curricular Models/ProbLab/Histo Blocks.nlogo
+++ b/Curricular Models/ProbLab/Histo Blocks.nlogo
@@ -160,7 +160,7 @@ to-report choose [n c]
 end
 
 to-report factorial [n]
-  report ifelse-value (n = 0) [
+  report ifelse-value n = 0 [
     1
   ] [
     n * factorial (n - 1)

--- a/HubNet Activities/Minority Game HubNet.nlogo
+++ b/HubNet Activities/Minority Game HubNet.nlogo
@@ -436,7 +436,7 @@ to update-client  ;; player procedure
   hubnet-send user-id "current choice" choice
   hubnet-send user-id "history" full-history player-history player-memory
   hubnet-send user-id "score" score
-  hubnet-send user-id "success rate" precision ifelse-value (choices-made > 0) [ score / choices-made ] [ 0 ] 2
+  hubnet-send user-id "success rate" precision ifelse-value choices-made > 0 [ score / choices-made ] [ 0 ] 2
 end
 
 ;; the client chooses 0 or 1

--- a/HubNet Activities/Root Beer Game HubNet.nlogo
+++ b/HubNet Activities/Root Beer Game HubNet.nlogo
@@ -151,7 +151,7 @@ to end-week ;; team procedure
   [
     ;; the demand starts at 4 cases per week. In week 7 it rises to
     ;; 8 cases and remains there the rest of the time.
-    set orders-placed ifelse-value ([clock] of myself <= 5) [ 4 ][ 8 ]
+    set orders-placed ifelse-value [clock] of myself <= 5 [ 4 ][ 8 ]
   ]
 
   ;; produce the goods at the factory level

--- a/HubNet Activities/Unverified/Predator Prey Game HubNet.nlogo
+++ b/HubNet Activities/Unverified/Predator Prey Game HubNet.nlogo
@@ -387,7 +387,7 @@ end
 to-report my-role
   if energy <= 0
     [ report "dead" ]
-  report ifelse-value (shape = "wolf") [ "predator" ][ "prey" ]
+  report ifelse-value shape = "wolf" [ "predator" ][ "prey" ]
 end
 
 ;; show the appropriate amount of energy

--- a/HubNet Activities/Unverified/Prisoners Dilemma HubNet.nlogo
+++ b/HubNet Activities/Unverified/Prisoners Dilemma HubNet.nlogo
@@ -261,7 +261,7 @@ end
 to set-code  ;; outputs the code to the input box, for students to see and modify
   if selected-strategy = "random"
     [ set user-code (word
-        "ifelse-value (random 2 = 0)\n"
+        "ifelse-value random 2 = 0\n"
         "  [DEFECT]\n"
         "  [COOPERATE]")
       stop ]
@@ -271,7 +271,7 @@ to set-code  ;; outputs the code to the input box, for students to see and modif
     [ set user-code ("DEFECT") stop ]
   if selected-strategy = "go-by-majority"
     [ set user-code (word
-        "ifelse-value (empty? play-history)\n"
+        "ifelse-value empty? play-history\n"
         "  [COOPERATE]\n"
         "  [ \n"
         "    ifelse-value (total-defects / (length play-history) > 0.5)\n"
@@ -280,48 +280,48 @@ to set-code  ;; outputs the code to the input box, for students to see and modif
       stop ]
   if selected-strategy = "tit-for-tat"
     [ set user-code (word
-        "ifelse-value (empty? play-history)\n"
+        "ifelse-value empty? play-history\n"
         "  [COOPERATE]\n"
         "  [\n"
-        "    ifelse-value (last play-partner-history = DEFECT)\n"
+        "    ifelse-value last play-partner-history = DEFECT\n"
         "      [DEFECT]\n"
         "      [COOPERATE]\n"
         "  ]") stop ]
   if selected-strategy = "suspicious-tit-for-tat"
     [ set user-code (word
-        "ifelse-value (empty? play-history)\n"
+        "ifelse-value empty? play-history\n"
         "  [DEFECT]\n"
         "  [ \n"
-        "    ifelse-value (last play-partner-history = DEFECT)\n"
+        "    ifelse-value last play-partner-history = DEFECT\n"
         "      [DEFECT]\n"
         "      [COOPERATE]\n"
         "  ]")
       stop ]
   if selected-strategy = "tit-for-two-tats"
     [ set user-code (word
-        "ifelse-value (length play-history < 2 )\n"
+        "ifelse-value length play-history < 2\n"
         "  [COOPERATE]\n"
         "  [\n"
-        "    ifelse-value ((last play-partner-history = DEFECT) and item (length play-partner-history - 2) play-partner-history = DEFECT)\n"
+        "    ifelse-value (last play-partner-history = DEFECT) and item (length play-partner-history - 2) play-partner-history = DEFECT\n"
         "      [DEFECT]\n"
         "      [COOPERATE]\n"
         "  ]")
       stop ]
   if selected-strategy = "pavlov"
     [ set user-code (word
-        "ifelse-value (empty? play-history) \n"
+        "ifelse-value empty? play-history \n"
         "  [\n"
-        "    ifelse-value (random 2 = 0) [DEFECT] [COOPERATE]\n"
+        "    ifelse-value random 2 = 0 [DEFECT] [COOPERATE]\n"
         "  ]\n"
         "  [ \n"
-        "    ifelse-value (last play-partner-history = DEFECT)\n"
+        "    ifelse-value last play-partner-history = DEFECT\n"
         "      [\n"
-        "        ifelse-value (last play-history = DEFECT)\n"
+        "        ifelse-value last play-history = DEFECT\n"
         "          [COOPERATE]\n"
         "          [DEFECT]\n"
         "      ]\n"
         "      [\n"
-        "        ifelse-value (last play-history = DEFECT)\n"
+        "        ifelse-value last play-history = DEFECT\n"
         "          [DEFECT]\n"
         "          [COOPERATE]\n"
         "      ]\n"
@@ -329,10 +329,10 @@ to set-code  ;; outputs the code to the input box, for students to see and modif
     stop ]
   if selected-strategy = "unforgiving"
     [ set user-code (word
-        "ifelse-value (empty? play-history)\n"
+        "ifelse-value empty? play-history\n"
         "  [COOPERATE] \n"
         "  [\n"
-        "    ifelse-value ((last play-partner-history = DEFECT) or (last play-history = DEFECT))\n"
+        "    ifelse-value (last play-partner-history = DEFECT) or (last play-history = DEFECT)\n"
         "      [DEFECT]\n"
         "      [COOPERATE]\n"
         "  ]")
@@ -539,14 +539,14 @@ to send-info-to-clients
   ifelse partner != nobody
   [
     hubnet-send user-id "Partner's Score:" ([score] of partner)
-    hubnet-send user-id "Partner's History:" (map [ b -> ifelse-value (b = true) ["D "] ["C "] ] play-partner-history)
-    hubnet-send user-id "Your History:" ( map [ b -> ifelse-value (b = true) ["D "] ["C "] ] play-history)
+    hubnet-send user-id "Partner's History:" (map [ b -> ifelse-value b = true ["D "] ["C "] ] play-partner-history)
+    hubnet-send user-id "Your History:" ( map [ b -> ifelse-value b = true ["D "] ["C "] ] play-history)
     hubnet-send user-id "Points:" (map [ [b1 b2] ->
-      ifelse-value ((b1 = false) and (b2 = false))
+      ifelse-value (b1 = false) and (b2 = false)
         [ C-C ]
-        [ ifelse-value ((b1 = false) and (b2 = true))
+        [ ifelse-value (b1 = false) and (b2 = true)
             [ C-D ]
-            [ ifelse-value ((b1 = true) and (b2 = false))
+            [ ifelse-value (b1 = true) and (b2 = false)
                 [ D-C ]
                 [ D-D ]
             ]

--- a/IABM Textbook/chapter 5/Traffic Basic Adaptive Individuals.nlogo
+++ b/IABM Textbook/chapter 5/Traffic Basic Adaptive Individuals.nlogo
@@ -114,13 +114,13 @@ end
 to-report upper-quartile [ xs ]
   let med median xs
   let upper filter [ x -> x > med ] xs
-  report ifelse-value (empty? upper) [ med ] [ median upper ]
+  report ifelse-value empty? upper [ med ] [ median upper ]
 end
 
 to-report lower-quartile [ xs ]
   let med median xs
   let lower filter [ x -> x < med ] xs
-  report ifelse-value (empty? lower) [ med ] [ median lower ]
+  report ifelse-value empty? lower [ med ] [ median lower ]
 end
 
 

--- a/Sample Models/Biology/Blood Sugar Regulation.nlogo
+++ b/Sample Models/Biology/Blood Sugar Regulation.nlogo
@@ -322,7 +322,7 @@ end
 ; Returns the outcome of a Bernoulli trial with success probability p.
 ; Successes are reported as 1 and failures are reported as 0.
 to-report random-bernoulli [ p ]
-  report ifelse-value (random-float 1 < p) [1] [0]
+  report ifelse-value random-float 1 < p [1] [0]
 end
 
 ; Returns a random number according to the binomial distribution with parameters n and p

--- a/Sample Models/Biology/Evolution/Echo.nlogo
+++ b/Sample Models/Biology/Evolution/Echo.nlogo
@@ -172,7 +172,7 @@ end
 ;; Mutates a given string
 to-report mutate [tag]
   report map [ letter ->
-    ifelse-value (random-float 100 >= mutation-rate)
+    ifelse-value random-float 100 >= mutation-rate
       [ letter ]
       [ one-of remove letter ["a" "b" "c"] ]
   ] tag
@@ -216,7 +216,7 @@ to-report match-score [tag1 tag2]
   if length tag2 > length tag1
     [ report (length tag1 - length tag2) + match-score tag1 sublist tag2 0 length tag1 ]
   report sum (map [ [letter1 letter2] ->
-    ifelse-value (letter1 = letter2) [2] [-2]
+    ifelse-value letter1 = letter2 [2] [-2]
   ] tag1 tag2)
 end
 

--- a/Sample Models/Biology/Evolution/Vision Evolution.nlogo
+++ b/Sample Models/Biology/Evolution/Vision Evolution.nlogo
@@ -96,7 +96,7 @@ end
 
 to move
   ; Determine the step size based on the land-mobility parameter
-  let step-size ifelse-value ( ycor < 0 ) [ 1 - land-mobility ] [ land-mobility ]
+  let step-size ifelse-value ycor < 0 [ 1 - land-mobility ] [ land-mobility ]
   ; Add a random element so that fish can make some progress on land even when land-mobility is 0
   set step-size step-size + random-float 0.1
 
@@ -201,7 +201,7 @@ end
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 to-report avg-eye-size [ agentset ]
-  let val ifelse-value (any? agentset)
+  let val ifelse-value any? agentset
     [ mean [ eye-size ] of agentset ]
     [ 1 ]
   report val
@@ -211,7 +211,7 @@ end
 to-report rad-size [ eye ]
   ; Eye size determines the radius of the field of vision
   ; The effect of eye size on the field of vision under water vs on land is vastly different
-  report ifelse-value ( ycor < 0 ) [ eye / max-eye-size + 3 ] [ ( eye ) ^ 2 + 3 ]
+  report ifelse-value ycor < 0 [ eye / max-eye-size + 3 ] [ ( eye ) ^ 2 + 3 ]
 end
 
 
@@ -221,7 +221,7 @@ to-report weighted-distance [ weight ]
   let mult 3
   ; Exponentials are used to model the weight of the food prefence
   ; Being close to 0.5 has little effect, but getting closer to one or zero has big effects
-  let dist ifelse-value ( ycor < 0 )
+  let dist ifelse-value ycor < 0
   [ (distance myself) * exp ((weight - 0.5)* mult) ]
   [ (distance myself) * exp ((0.5 - weight)* mult) ]
   report dist

--- a/Sample Models/Chemistry & Physics/Diffusion Limited Aggregation/DLA Alternate Linear.nlogo
+++ b/Sample Models/Chemistry & Physics/Diffusion Limited Aggregation/DLA Alternate Linear.nlogo
@@ -121,7 +121,7 @@ to-report collision-distance [ incoming ]  ;; stayer procedure
 end
 
 to-report sign-star [ x ]
-  report ifelse-value (x < 0) [-1] [1]
+  report ifelse-value x < 0 [-1] [1]
 end
 
 

--- a/Sample Models/Chemistry & Physics/Diffusion Limited Aggregation/DLA Alternate.nlogo
+++ b/Sample Models/Chemistry & Physics/Diffusion Limited Aggregation/DLA Alternate.nlogo
@@ -112,7 +112,7 @@ to-report collision-distance [incoming]  ;; stayer procedure
 end
 
 to-report sign-star [x]
-  report ifelse-value (x < 0) [-1] [1]
+  report ifelse-value x < 0 [-1] [1]
 end
 
 

--- a/Sample Models/Computer Science/Artificial Neural Net - Multilayer.nlogo
+++ b/Sample Models/Computer Science/Artificial Neural Net - Multilayer.nlogo
@@ -170,7 +170,7 @@ end
 
 ;; computes the step function given an input value and the weight on the link
 to-report step [input]
-  report ifelse-value (input > 0.5) [ 1 ] [ 0 ]
+  report ifelse-value input > 0.5 [ 1 ] [ 0 ]
 end
 
 ;;;
@@ -180,7 +180,7 @@ end
 ;; test runs one instance and computes the output
 to test
   let result result-for-inputs input-1 input-2
-  let correct? ifelse-value (result = target-answer) [ "correct" ] [ "incorrect" ]
+  let correct? ifelse-value result = target-answer [ "correct" ] [ "incorrect" ]
   user-message (word
     "The expected answer for " input-1 " " target-function " " input-2 " is " target-answer ".\n\n"
     "The network reported " result ", which is " correct? ".")

--- a/Sample Models/Computer Science/Artificial Neural Net - Perceptron.nlogo
+++ b/Sample Models/Computer Science/Artificial Neural Net - Perceptron.nlogo
@@ -165,7 +165,7 @@ end
 to-report target-answer ;; observer procedure
   let a [activation] of input-node-1 = 1
   let b [activation] of input-node-2 = 1
-  report ifelse-value (run-result (word "my-" target-function " a b")) [1][-1]
+  report ifelse-value run-result (word "my-" target-function " a b") [1][-1]
 end
 
 to-report my-or [a b];; output-node procedure

--- a/Sample Models/Computer Science/Robby the Robot.nlogo
+++ b/Sample Models/Computer Science/Robby the Robot.nlogo
@@ -294,7 +294,7 @@ end
 
 to mutate   ;; individual procedure
   set chromosome map [ action ->
-    ifelse-value (random-float 1 < mutation-rate)
+    ifelse-value random-float 1 < mutation-rate
       [random-action]
       [action]
   ] chromosome
@@ -323,11 +323,11 @@ to-report state
   let east patch-at 1 0
   let south patch-at 0 -1
   let west patch-at -1 0
-  report ifelse-value (is-patch? north) [ifelse-value (any? cans-on north) [81] [0]] [162] +
-         ifelse-value (is-patch? east ) [ifelse-value (any? cans-on east ) [27] [0]] [ 54] +
-         ifelse-value (is-patch? south) [ifelse-value (any? cans-on south) [ 9] [0]] [ 18] +
-         ifelse-value (is-patch? west ) [ifelse-value (any? cans-on west ) [ 3] [0]] [  6] +
-                                         ifelse-value (any? cans-here)     [ 1] [0]
+  report (ifelse-value is-patch? north [ifelse-value any? cans-on north [81] [0]] [162]) +
+         (ifelse-value is-patch? east  [ifelse-value any? cans-on east  [27] [0]] [ 54]) +
+         (ifelse-value is-patch? south [ifelse-value any? cans-on south [ 9] [0]] [ 18]) +
+         (ifelse-value is-patch? west  [ifelse-value any? cans-on west  [ 3] [0]] [  6]) +
+         (ifelse-value any? cans-here [1] [0])
 end
 
 ;; Below are the definitions of Robby's seven basic actions
@@ -406,7 +406,7 @@ end
 
 ;; count the number of occurrences of an item in a list
 to-report occurrences [x a-list]
-  report reduce [ [n the-item] -> ifelse-value (the-item = x) [ n + 1 ] [ n ] ] (fput 0 a-list)
+  report reduce [ [n the-item] -> ifelse-value the-item = x [ n + 1 ] [ n ] ] (fput 0 a-list)
 end
 
 ;; measure distance between two chromosomes
@@ -418,7 +418,7 @@ to-report chromosome-distance [individual1 individual2]
   ;; scale the distance to fit in the view
   let dist-candidate max-pxcor * sqrt dist2 / ( max-dist / 10)
   ;; if distance is too large, report the edge of the view
-  report ifelse-value (dist-candidate > max-pxcor) [max-pxcor] [dist-candidate]
+  report ifelse-value dist-candidate > max-pxcor [max-pxcor] [dist-candidate]
 end
 
 

--- a/Sample Models/Computer Science/Simple Genetic Algorithm.nlogo
+++ b/Sample Models/Computer Science/Simple Genetic Algorithm.nlogo
@@ -134,7 +134,7 @@ end
 ;; MUTATION-RATE slider.
 to mutate   ;; turtle procedure
   set bits map [ b ->
-    ifelse-value (random-float 100.0 < mutation-rate)
+    ifelse-value random-float 100.0 < mutation-rate
       [ 1 - b ]
       [ b ]
   ] bits

--- a/Sample Models/Philosophy/Signaling Game.nlogo
+++ b/Sample Models/Philosophy/Signaling Game.nlogo
@@ -243,8 +243,8 @@ to-report format-list [ this-list ]
 end
 
 to-report format-value [ x width ]
-  let str (word ifelse-value (is-number? x) [ precision x 0 ] [ x ])
-  let padding ifelse-value (length str < width)
+  let str (word ifelse-value is-number? x [ precision x 0 ] [ x ])
+  let padding ifelse-value length str < width
     [ reduce word (n-values (width - length str) [ " " ]) ]
     [ "" ]
   report word padding str
@@ -257,7 +257,7 @@ end
 
 to-report instances [ x this-list ]
   ; report the number of instances of x in this-list
-  report reduce [ [a b] -> a + ifelse-value (b = x) [ 1 ] [ 0 ] ] fput 0 this-list
+  report reduce [ [a b] -> a + ifelse-value b = x [ 1 ] [ 0 ] ] fput 0 this-list
 end
 
 to-report normalize [ this-list ]

--- a/Sample Models/Social Science/Bidding Market.nlogo
+++ b/Sample Models/Social Science/Bidding Market.nlogo
@@ -69,7 +69,7 @@ to setup
     set asking-price get-starting-value starting-asking-price
     ; we set the behavior using anonymous procedures to make the usage during the run simple
     ; the behavior depends on the settings of the model
-    let mix-behavior ifelse-value (seller-behavior = "mix of all") [random 3] [-1]
+    let mix-behavior ifelse-value seller-behavior = "mix of all" [random 3] [-1]
     ifelse seller-behavior = "normal" or mix-behavior = 0 [
       set behavior-after-sale [         -> change-price 2.5 ]
       set behavior-no-sale    [ hide? -> if (not hide?) [ change-price -2.0 ] ]
@@ -95,7 +95,7 @@ to setup
     set willing-to-pay get-starting-value starting-willing-to-pay
     ; we set the behavior using anonymous procedures to make the usage during the run simple
     ; again, the behavior depends on the settings of the model
-    let mix-behavior ifelse-value (buyer-behavior = "mix of all") [random 3] [-1]
+    let mix-behavior ifelse-value buyer-behavior = "mix of all" [random 3] [-1]
     ifelse buyer-behavior = "normal" or mix-behavior = 0 [
       set behavior-after-purchase [-> change-payment -2.0 ]
       set behavior-no-purchase    [-> change-payment  2.5 ]
@@ -144,7 +144,7 @@ to setup
 end
 
 to-report get-random-amount [ dist amount ]
-  report ifelse-value (dist = "even") [
+  report ifelse-value dist = "even" [
     1 + random (get-amount amount)
   ] [ ; "concentrated"
     1 + floor random-exponential ((get-amount amount) / 2)
@@ -152,7 +152,7 @@ to-report get-random-amount [ dist amount ]
 end
 
 to-report get-amount [ amount ]
-  report ifelse-value (amount = "high") [
+  report ifelse-value amount = "high" [
     amount-high
   ] [ ; else "low"
     amount-low
@@ -172,7 +172,7 @@ to go
   ; move our buyers to their next position in the circle
   ; record the positions first, since if we move before processing all of them, it screws things up
   ask buyers [
-    let next ifelse-value (who = (1 * population)) [(2 * population) - 1] [who - 1]
+    let next ifelse-value who = (1 * population) [(2 * population) - 1] [who - 1]
     set next-xcor [xcor] of buyer next
     set next-ycor [ycor] of buyer next
   ]
@@ -240,7 +240,7 @@ to do-commerce-with [ the-seller ]
     set want-to-buy (want-to-buy - 1)
     let price asking
     set money precision (money - price) 2
-    set money ifelse-value (money < min-price) [0] [money]
+    set money ifelse-value money < min-price [0] [money]
     set bought (bought + 1)
     ask the-seller [
       set items-for-sale (items-for-sale - 1)
@@ -319,7 +319,7 @@ to-report seller-cash
 end
 
 to-report average-price
-  report (ifelse-value (total-sales = 0) [ 0.00 ] [ precision (seller-cash / total-sales) 2 ])
+  report (ifelse-value total-sales = 0 [ 0.00 ] [ precision (seller-cash / total-sales) 2 ])
 end
 
 to-report percent-money-taken
@@ -335,7 +335,7 @@ to-report percent-demand-satisfied
 end
 
 to-report check-for-min-price [ value ]
-  report precision ifelse-value (value < min-price) [min-price] [value] 2
+  report precision ifelse-value value < min-price [min-price] [value] 2
 end
 
 
@@ -417,7 +417,7 @@ NIL
 100.0
 true
 false
-"" "let top (floor ifelse-value (average-price = 0) [max [asking-price] of sellers] [average-price * 2])\nset-plot-y-range 0 ifelse-value (top < 1) [1] [top]"
+"" "let top (floor ifelse-value average-price = 0 [max [asking-price] of sellers] [average-price * 2])\nset-plot-y-range 0 ifelse-value top < 1 [1] [top]"
 PENS
 "avg-asking-price" 1.0 0 -13345367 true "" "let ss (sellers with [items-for-sale > 0])\nifelse (count ss = 0) \n[ plot 0 ]\n[ plot mean [asking-price] of ss ]"
 "min-asking-price" 1.0 0 -5325092 true "" "let ss (sellers with [items-for-sale > 0])\nifelse (count ss = 0) \n[ plot 0 ]\n[ plot min [asking-price] of ss ]"
@@ -511,7 +511,7 @@ NIL
 100.0
 true
 false
-"" "let top floor ifelse-value (average-price = 0) [max [asking-price] of sellers] [average-price * 2]\nset-plot-y-range 0 ifelse-value (top < 1) [1] [top]"
+"" "let top floor ifelse-value average-price = 0 [max [asking-price] of sellers] [average-price * 2]\nset-plot-y-range 0 ifelse-value top < 1 [1] [top]"
 PENS
 "avg-willing" 1.0 0 -5825686 true "" "let bs (buyers with [want-to-buy > 0 and money > 0])\nifelse (count bs = 0) \n[ plot 0 ]\n[ plot mean [willing-to-pay] of bs ]"
 "max-willing" 1.0 0 -2382653 true "" "let bs (buyers with [want-to-buy > 0 and money > 0])\nifelse (count bs = 0) \n[ plot 0 ]\n[ plot max [willing-to-pay] of bs ]"

--- a/Sample Models/Social Science/Hotelling's Law.nlogo
+++ b/Sample Models/Social Science/Hotelling's Law.nlogo
@@ -26,7 +26,7 @@ end
 to setup-consumers
   ; Store the agentset of patches that are going to be our
   ; consumers in a global variable for easy reference.
-  set consumers ifelse-value (layout = "line")
+  set consumers ifelse-value layout = "line"
     [ patches with [ pxcor = 0 ] ]
     [ patches ]
 end
@@ -51,11 +51,11 @@ to go
   ; We accumulate location and price changes as lists of tasks to be run later
   ; in order to simulate simultaneous decision making on the part of the stores
 
-  let location-changes ifelse-value (rules = "pricing-only")
+  let location-changes ifelse-value rules = "pricing-only"
     [ (list) ] ; if we are doing "pricing-only", the list of moves is empty
     [ [ new-location-task ] of turtles ]
 
-  let price-changes ifelse-value (rules = "moving-only")
+  let price-changes ifelse-value rules = "moving-only"
     [ (list) ] ; if we are doing "moving-only", the list of price changes is empty
     [ [ new-price-task ] of turtles ]
 
@@ -141,7 +141,7 @@ to-report new-price-task
     map [ the-price -> list the-price (potential-revenue the-price) ] possible-prices
 
   let all-zeros? (not member? false map [ pair -> last pair = 0 ] prices-with-revenues)
-  let chosen-price ifelse-value (all-zeros? and price > 1)
+  let chosen-price ifelse-value all-zeros? and price > 1
     [ price - 1 ] ; if all potential revenues are zero, the store lowers its price as an emergency procedure if it can
     [ first first prices-with-revenues ] ; in any other case, we pick the price with the best potential revenues
 

--- a/Sample Models/Social Science/Language Change.nlogo
+++ b/Sample Models/Social Science/Language Change.nlogo
@@ -84,7 +84,7 @@ end
 
 ;; reports a string of the agent's initial grammar
 to-report orig-grammar-string
-  report ifelse-value (orig-state = 1.0) ["1"] ["0"]
+  report ifelse-value orig-state = 1.0 ["1"] ["0"]
 end
 
 ;;;

--- a/Sample Models/Social Science/Minority Game.nlogo
+++ b/Sample Models/Social Science/Minority Game.nlogo
@@ -115,7 +115,7 @@ to increment-scores  ;; turtles procedure
   ;; the minority.  If it did, we increase its score by one,
   ;; otherwise we leave the score alone.
   set strategies-scores (map [ [the-strategy the-score] ->
-    ifelse-value (item history the-strategy = minority) [ the-score + 1] [ the-score ]
+    ifelse-value item history the-strategy = minority [ the-score + 1] [ the-score ]
   ] strategies strategies-scores)
 end
 

--- a/Sample Models/Social Science/Traffic 2 Lanes.nlogo
+++ b/Sample Models/Social Science/Traffic 2 Lanes.nlogo
@@ -144,7 +144,7 @@ to choose-new-lane ; turtle procedure
 end
 
 to move-to-target-lane ; turtle procedure
-  set heading ifelse-value (target-lane < ycor) [ 180 ] [ 0 ]
+  set heading ifelse-value target-lane < ycor [ 180 ] [ 0 ]
   let blocking-cars other turtles in-cone (1 + abs (ycor - target-lane)) 180 with [ x-distance <= 1 ]
   let blocking-car min-one-of blocking-cars [ distance myself ]
   ifelse blocking-car = nobody [

--- a/Sample Models/System Dynamics/Unverified/Tabonuco Yagrumo Hybrid.nlogo
+++ b/Sample Models/System Dynamics/Unverified/Tabonuco Yagrumo Hybrid.nlogo
@@ -757,7 +757,7 @@ NetLogo 6.0.4
         org.nlogo.sdm.gui.ConverterFigure "attributes" "attributes" 1 "FillColor" "Color" 130 188 183 441 503 50 50
             org.nlogo.sdm.gui.WrappedConverter "user-hurricane-interval" "hurricane-interval"
         org.nlogo.sdm.gui.ConverterFigure "attributes" "attributes" 1 "FillColor" "Color" 130 188 183 357 418 50 50
-            org.nlogo.sdm.gui.WrappedConverter ";; We always have at least 0.001 disturbance,\n;; If hurricane frequency is above 0, then\n;; we have a hurricane strike at a regular\n;; otherwise we have a single hurricane strike\n;; at time 0\n0.001 + ifelse-value ( hurricane-interval = 0 )\n  [ pulse hurricane-strength 0 0]\n  [ pulse hurricane-strength hurricane-interval hurricane-interval ]\n" "disturbance"
+            org.nlogo.sdm.gui.WrappedConverter ";; We always have at least 0.001 disturbance,\n;; If hurricane frequency is above 0, then\n;; we have a hurricane strike at a regular\n;; otherwise we have a single hurricane strike\n;; at time 0\n0.001 + ifelse-value hurricane-interval = 0\n  [ pulse hurricane-strength 0 0]\n  [ pulse hurricane-strength hurricane-interval hurricane-interval ]\n" "disturbance"
         org.nlogo.sdm.gui.BindingConnection 2 453 515 394 455 NULL NULL 0 0 0
             org.jhotdraw.contrib.ChopDiamondConnector REF 5
             org.jhotdraw.contrib.ChopDiamondConnector REF 7
@@ -770,7 +770,7 @@ NetLogo 6.0.4
         org.nlogo.sdm.gui.ConverterFigure "attributes" "attributes" 1 "FillColor" "Color" 130 188 183 351 35 50 50
             org.nlogo.sdm.gui.WrappedConverter "amount-of-tabonuco + amount-of-yagrumo" "carbon"
         org.nlogo.sdm.gui.ConverterFigure "attributes" "attributes" 1 "FillColor" "Color" 130 188 183 472 28 50 50
-            org.nlogo.sdm.gui.WrappedConverter ";; this is the equivalent of derivn(carbon, 1)\n;; in Stella, however we have to explicitly\n;; track the previous value, see the GO procedure\nifelse-value ( previous-carbon = 0 )\n [ 0 ]\n [ max (list 0 ( ( carbon - previous-carbon) / dt ) )] " "productivity"
+            org.nlogo.sdm.gui.WrappedConverter ";; this is the equivalent of derivn(carbon, 1)\n;; in Stella, however we have to explicitly\n;; track the previous value, see the GO procedure\nifelse-value previous-carbon = 0\n [ 0 ]\n [ max (list 0 ( ( carbon - previous-carbon) / dt ) )] " "productivity"
         org.nlogo.sdm.gui.BindingConnection 2 246 256 304 152 NULL NULL 0 0 0
             org.jhotdraw.standard.ChopBoxConnector REF 1
             org.jhotdraw.contrib.ChopDiamondConnector REF 12

--- a/Sample Models/System Dynamics/Unverified/Tabonuco Yagrumo.nlogo
+++ b/Sample Models/System Dynamics/Unverified/Tabonuco Yagrumo.nlogo
@@ -659,7 +659,7 @@ need-to-manually-make-preview-for-this-model
         org.nlogo.sdm.gui.ConverterFigure "attributes" "attributes" 1 "FillColor" "Color" 130 188 183 748 148 50 50
             org.nlogo.sdm.gui.WrappedConverter "0.20" "yagrumo-growth-rate"
         org.nlogo.sdm.gui.ConverterFigure "attributes" "attributes" 1 "FillColor" "Color" 130 188 183 435 209 50 50
-            org.nlogo.sdm.gui.WrappedConverter ";; We always have at least 0.001 disturbance,\n;; If hurricane interval is above 0, then\n;; we have a hurricane strike at a regular\n;; otherwise we have a single hurricane strike\n;; at time 0\n0.001 + ifelse-value ( hurricane-interval = 0 )\n  [ pulse hurricane-strength 0 0]\n  [ pulse hurricane-strength hurricane-interval hurricane-interval ]\n" "disturbance"
+            org.nlogo.sdm.gui.WrappedConverter ";; We always have at least 0.001 disturbance,\n;; If hurricane interval is above 0, then\n;; we have a hurricane strike at a regular\n;; otherwise we have a single hurricane strike\n;; at time 0\n0.001 + ifelse-value hurricane-interval = 0\n  [ pulse hurricane-strength 0 0]\n  [ pulse hurricane-strength hurricane-interval hurricane-interval ]\n" "disturbance"
         org.nlogo.sdm.gui.ConverterFigure "attributes" "attributes" 1 "FillColor" "Color" 130 188 183 291 271 50 50
             org.nlogo.sdm.gui.WrappedConverter "0.065" "tabonuco-growth-rate"
         org.nlogo.sdm.gui.BindingConnection 2 502 279 471 247 NULL NULL 0 0 0
@@ -683,7 +683,7 @@ need-to-manually-make-preview-for-this-model
         org.nlogo.sdm.gui.ConverterFigure "attributes" "attributes" 1 "FillColor" "Color" 130 188 183 446 423 50 50
             org.nlogo.sdm.gui.WrappedConverter "amount-of-tabonuco + amount-of-yagrumo" "carbon"
         org.nlogo.sdm.gui.ConverterFigure "attributes" "attributes" 1 "FillColor" "Color" 130 188 183 571 422 50 50
-            org.nlogo.sdm.gui.WrappedConverter ";; this is the equivalent of derivn(carbon, 1)\n;; in Stella, however we have to explicitly\n;; track the previous value, see the GO procedure\nifelse-value ( previous-carbon = 0 )\n [ 0 ]\n [ max (list 0 ( ( carbon - previous-carbon) / dt ) )] " "productivity"
+            org.nlogo.sdm.gui.WrappedConverter ";; this is the equivalent of derivn(carbon, 1)\n;; in Stella, however we have to explicitly\n;; track the previous value, see the GO procedure\nifelse-value previous-carbon = 0\n [ 0 ]\n [ max (list 0 ( ( carbon - previous-carbon) / dt ) )] " "productivity"
         org.nlogo.sdm.gui.BindingConnection 2 118 396 307 541 NULL NULL 0 0 0
             org.jhotdraw.standard.ChopBoxConnector REF 3
             org.jhotdraw.contrib.ChopDiamondConnector REF 31


### PR DESCRIPTION
This is in response to NetLogo/NetLogo#1668. The following changes need to be made:

- [x] Due to a breaking change resulting from the fix to NetLogo/NetLogo#588, `Robby the Robot` needs to be updated due to its use of `ifelse-value` expressions as arguments to infix operators.

- [x] Since `ifelse-value` no longer requires parentheses around its conditional reporters, these should be removed from existing models.

- [x] Models that use nested `ifelse` or `ifelse-value` in order to emulate variadic versions of the same prims will be updated accordingly. (Edit: There isn't a particularly easy way to do this unfortunately because of the different structures of the nested calls in order to ensure the logic is identical, particularly the default actions. As such, this might be pushed to a later set of changes.)