### PR TITLE
Reactor X-Section: Fix typo and extend manual rod depth

### DIFF
--- a/Sample Models/Chemistry & Physics/Radioactivity/Unverified/Reactor X-Section.nlogo
+++ b/Sample Models/Chemistry & Physics/Radioactivity/Unverified/Reactor X-Section.nlogo
@@ -334,7 +334,7 @@ SLIDER
 rod-depth
 rod-depth
 0
-80
+reactor-size
 0.0
 1
 1
@@ -389,7 +389,7 @@ spend-fuel?
 
 This project simulates a nuclear fission reaction in a nuclear power plant. In a fission reaction, free neutrons hit uranium atoms, causing each uranium atom to generate 2 or 3 neutrons and a unit of energy. The uranium atom itself splits into two smaller atoms. The newly generated neutrons, together with the neutron that caused the reaction, keep moving and continue to hit more uranium atoms, which release more neutrons, etc.  This is the chain reaction that happens inside an atomic bomb.
 
-Most nuclear energy is used for peaceful purpose, however. Generated in a nuclear power plant, nuclear fission goes on in a much more controlled fashion. Heavy metal plates made of lead help to absorb the free neutrons, thus fewer atoms of uranium are smashed, which in turn limits how much energy is released.
+Most nuclear energy is used for peaceful purposes, however. Generated in a nuclear power plant, nuclear fission goes on in a much more controlled fashion. Heavy metal plates made of lead help to absorb the free neutrons, thus fewer atoms of uranium are smashed, which in turn limits how much energy is released.
 
 This model simulates the process of a nuclear fission reaction inside such a plant. The reactor core is built of concrete, with adjustable control rods to help control the speed of the reaction. The reactor has a built-in automatic controller, and has a set of manual controls as well.
 


### PR DESCRIPTION
I realize this is not the most important update in the world, but I was very frustrated when I discovered that the automated system could lower the control rods to the full depth of the reactor, whereas I, the lowly human, could only drop them to about 80%, meaning the algorithm always did better than me at getting a consistent reaction by, essentially, cheating.  Also, fixed a typo.