### PR TITLE
Visual Fix: Adjusted link thickness to keep the background clear

### DIFF
--- a/Sample Models/Computer Science/Artificial Neural Net - Perceptron.nlogo
+++ b/Sample Models/Computer Science/Artificial Neural Net - Perceptron.nlogo
@@ -233,7 +233,7 @@ to resize-recolor-links
     ifelse show-weights?
     [ set label precision weight 4 ]
     [ set label "" ]
-    set thickness 0.05 * abs weight
+    set thickness 0.2 * abs weight
     ifelse weight > 0
       [ set color [ 255 0 0 196 ] ]   ; transparent red
       [ set color [ 0 0 255 196 ] ] ; transparent light blue

--- a/Sample Models/Computer Science/Artificial Neural Net - Perceptron.nlogo
+++ b/Sample Models/Computer Science/Artificial Neural Net - Perceptron.nlogo
@@ -233,7 +233,7 @@ to resize-recolor-links
     ifelse show-weights?
     [ set label precision weight 4 ]
     [ set label "" ]
-    set thickness 0.1 + 20 * abs weight
+    set thickness 0.05 * abs weight
     ifelse weight > 0
       [ set color [ 255 0 0 196 ] ]   ; transparent red
       [ set color [ 0 0 255 196 ] ] ; transparent light blue


### PR DESCRIPTION
In the Perceptron model, links would grow large after
a couple of training sessions in the model and would
cover the screen, causing the background to change
color.