### PR TITLE
Small Worlds: Expect cluster coefficient to be undefined for highlight

### DIFF
--- a/Sample Models/Networks/Small Worlds.nlogo
+++ b/Sample Models/Networks/Small Worlds.nlogo
@@ -329,7 +329,10 @@ to do-highlight
       let my-apl (sum remove infinity distance-from-other-turtles) / pairs
 
       ; show node's statistics
-      set highlight-string (word "clustering coefficient = " precision my-clustering-coefficient 3
+      let coefficient-description ifelse-value my-clustering-coefficient = "undefined"
+        ["undefined for single-link"]
+        [precision my-clustering-coefficient 3]
+      set highlight-string (word "clustering coefficient = " coefficient-description
         " and avg path length = " precision my-apl 3
         " (for " pairs " turtles )")
     ]


### PR DESCRIPTION
The `my-clustering-coefficient` variable can be set to the string value `"undefined"` when a node has a single link, but later is expected to be a number value used with `precision`.  This change guards against the runtime error that gets generated in that scenario.