### PR TITLE
Compatibility: Update `mouse-down?` uses to work in NetLogo Web

### DIFF
--- a/Sample Models/Biology/Evolution/Sunflower Biomorphs.nlogo
+++ b/Sample Models/Biology/Evolution/Sunflower Biomorphs.nlogo
@@ -5,6 +5,7 @@ breed [petals petal]
 
 globals [
   first-parent     ;; the first parent chosen if sexual reproduction is being used
+  mouse-handled?   ;; if we already handled a mouse-down? event
 ]
 
 spawners-own [
@@ -36,6 +37,7 @@ to setup
   ]
   arrange-spawners
   set first-parent nobody
+  set mouse-handled? false
   reset-ticks
 end
 
@@ -77,7 +79,14 @@ to go
     if abs (ycor - [ycor] of parent) > max-pycor / (rows * 1.5) [ die ]
   ]
   tick
-  if mouse-down? [ handle-mouse-down ]
+  ifelse mouse-down? [
+    if not mouse-handled? [
+      handle-mouse-down
+      set mouse-handled? true
+    ]
+  ] [
+    set mouse-handled? false
+  ]
 end
 
 to repopulate-from-two [parent1 parent2]
@@ -138,8 +147,6 @@ to handle-mouse-down
       ]
     ]
   ]
-  ;; wait for the user to release mouse button
-  while [mouse-down?] [ ]
 end
 
 

--- a/Sample Models/Chemistry & Physics/Mechanics/Unverified/N-Bodies.nlogo
+++ b/Sample Models/Chemistry & Physics/Mechanics/Unverified/N-Bodies.nlogo
@@ -12,6 +12,7 @@ globals
 [ center-of-mass-yc ;; y-coordinate of the center of mass
   center-of-mass-xc ;; x-coordinate of the center of mass
   g  ;; Gravitational Constant
+  mouse-handled?    ;; did we already handle the create particle mouse event?
 ]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;
@@ -70,30 +71,38 @@ to zero-sum-initial-setup
 end
 
 to create-particle
-  if mouse-down?
-  [ let mx mouse-xcor
-    let my mouse-ycor
-    if (not any? turtles-on patch mx my)
-    [
-      create-turtles 1
-      [ set xc mx ;initial-position-x
-        set yc my ;initial-position-y
-        setxy xc yc
-        set vx initial-velocity-x
-        set vy initial-velocity-y
-        set mass initial-mass
-        set size sqrt mass
-        set color particle-color
+  if mouse-handled? = 0 [
+    set mouse-handled? false
+  ]
+
+  ifelse mouse-down?
+  [
+    if not mouse-handled? [
+      let mx mouse-xcor
+      let my mouse-ycor
+      if (not any? turtles-on patch mx my)
+      [
+        create-turtles 1
+        [ set xc mx ;initial-position-x
+          set yc my ;initial-position-y
+          setxy xc yc
+          set vx initial-velocity-x
+          set vy initial-velocity-y
+          set mass initial-mass
+          set size sqrt mass
+          set color particle-color
+        ]
+        display
       ]
+      set mouse-handled? true
+    ]
+  ] [
+    if mouse-handled? and keep-centered?
+    [
+      recenter
       display
     ]
-  ]
-  while [mouse-down?]
-  []
-  if keep-centered?
-  [
-    recenter
-    display
+    set mouse-handled? false
   ]
 end
 

--- a/Sample Models/Chemistry & Physics/Waves/Lattice Gas Automaton.nlogo
+++ b/Sample Models/Chemistry & Physics/Waves/Lattice Gas Automaton.nlogo
@@ -52,11 +52,14 @@ to swap-pcolor [p1 p2]
 end
 
 to draw-circle
-  while [mouse-down?]
-    [ ask patch mouse-xcor mouse-ycor
-        [ ask patches in-radius radius
-            [ set pcolor black ] ]
-      display ]
+  if mouse-down? [
+    ask patch mouse-xcor mouse-ycor [
+      ask patches in-radius radius [
+        set pcolor black
+      ]
+    ]
+    display
+  ]
 end
 
 

--- a/Sample Models/Computer Science/Cellular Automata/Brian's Brain.nlogo
+++ b/Sample Models/Computer Science/Cellular Automata/Brian's Brain.nlogo
@@ -1,3 +1,7 @@
+globals [
+  erasing?          ;; is the current draw-cells mouse click erasing or adding?
+]
+
 patches-own [
   firing?           ;; white cells
   refractory?       ;; red cells
@@ -56,15 +60,25 @@ to go
 end
 
 to draw-cells [target-color]
-  let erasing? target-color = [pcolor] of patch mouse-xcor mouse-ycor
-  while [mouse-down?]
-    [ ask patch mouse-xcor mouse-ycor
-      [ ifelse erasing?
-        [ cell-death ]
-        [ ifelse target-color = white
-          [ cell-birth ]
-          [ cell-aging ] ] ]
-      display ]
+  ifelse mouse-down? [
+    if erasing? = 0 [
+      set erasing? target-color = [pcolor] of patch mouse-xcor mouse-ycor
+    ]
+    ask patch mouse-xcor mouse-ycor [
+      ifelse erasing? [
+        cell-death
+      ] [
+        ifelse target-color = white [
+          cell-birth
+        ] [
+          cell-aging
+        ]
+      ]
+    ]
+    display
+  ] [
+    set erasing? 0
+  ]
 end
 
 

--- a/Sample Models/Computer Science/Cellular Automata/Life Turtle-Based.nlogo
+++ b/Sample Models/Computer Science/Cellular Automata/Life Turtle-Based.nlogo
@@ -1,6 +1,10 @@
 breed [cells cell]    ;; living cells
 breed [babies baby]   ;; show where a cell will be born
 
+globals [
+  erasing?        ;; is the current draw-cells mouse click erasing or adding?
+]
+
 patches-own [
   live-neighbors  ;; count of how many neighboring cells are alive
 ]
@@ -67,13 +71,21 @@ end
 
 ;; user adds or removes cells with the mouse
 to draw-cells
-  let erasing? any? cells-on patch mouse-xcor mouse-ycor
-  while [mouse-down?]
-    [ ask patch mouse-xcor mouse-ycor
-      [ ifelse erasing?
-        [ erase ]
-        [ draw ] ]
-    display ]
+  ifelse mouse-down? [
+    if erasing? = 0 [
+      set erasing? any? cells-on patch mouse-xcor mouse-ycor
+    ]
+    ask patch mouse-xcor mouse-ycor [
+      ifelse erasing? [
+        erase
+      ] [
+        draw
+      ]
+    ]
+    display
+  ] [
+    set erasing? 0
+  ]
 end
 
 ;; user adds a cell with the mouse

--- a/Sample Models/Computer Science/Cellular Automata/Life.nlogo
+++ b/Sample Models/Computer Science/Cellular Automata/Life.nlogo
@@ -1,3 +1,7 @@
+globals [
+  erasing?        ;; is the current draw-cells mouse click erasing or adding?
+]
+
 patches-own [
   living?         ;; indicates if the cell is living
   live-neighbors  ;; counts how many neighboring cells are alive
@@ -44,13 +48,21 @@ to go
 end
 
 to draw-cells
-  let erasing? [living?] of patch mouse-xcor mouse-ycor
-  while [mouse-down?]
-    [ ask patch mouse-xcor mouse-ycor
-      [ ifelse erasing?
-        [ cell-death ]
-        [ cell-birth ] ]
-      display ]
+  ifelse mouse-down? [
+    if erasing? = 0 [
+      set erasing? [living?] of patch mouse-xcor mouse-ycor
+    ]
+    ask patch mouse-xcor mouse-ycor [
+      ifelse erasing? [
+        cell-death
+      ] [
+        cell-birth
+      ]
+    ]
+    display
+  ] [
+    set erasing? 0
+  ]
 end
 
 

--- a/Sample Models/Mathematics/Unverified/PANDA BEAR Solo.nlogo
+++ b/Sample Models/Mathematics/Unverified/PANDA BEAR Solo.nlogo
@@ -4,6 +4,7 @@
 
 globals [
   red-vertex          ;; the red vertex
+  click-vertex        ;; the mouse clicked vertex
 ]
 
 breed [ vertices vertex ]
@@ -79,25 +80,29 @@ end
 ;;
 
 to go
-  if mouse-down? [
-    ;; clicking "picks up" the closest vertex
-    ask min-one-of vertices [ distancexy mouse-xcor mouse-ycor ] [
+  ifelse mouse-down? [
+    ifelse click-vertex = 0 [
+      ;; clicking "picks up" the closest vertex
+      set click-vertex min-one-of vertices [ distancexy mouse-xcor mouse-ycor ]
       ;; if the mouse is more than 1 patch away from any
       ;; vertex just ignore the click.
-      if distancexy mouse-xcor mouse-ycor < 1
-      [
-        while [mouse-down?] [
-          ;; use EVERY to limit how much data we end up plotting
-          every 0.05 [
-            ;; don't move vertices directly on top of one another
-            if all? other vertices [ xcor != mouse-xcor or ycor != mouse-ycor ] [
-              setxy mouse-xcor mouse-ycor
-              update
-            ]
+      if [distancexy mouse-xcor mouse-ycor] of click-vertex >= 1 [
+        set click-vertex 0
+      ]
+    ] [
+      ;; use EVERY to limit how much data we end up plotting
+      every 0.05 [
+        ask click-vertex [
+          ;; don't move vertices directly on top of one another
+          if all? other vertices [ xcor != mouse-xcor or ycor != mouse-ycor ] [
+            setxy mouse-xcor mouse-ycor
+            update
           ]
         ]
       ]
     ]
+  ] [
+    set click-vertex 0
   ]
 end
 

--- a/Sample Models/Mathematics/Unverified/Surface Walking 2D.nlogo
+++ b/Sample Models/Mathematics/Unverified/Surface Walking 2D.nlogo
@@ -41,7 +41,7 @@ end
 ;; ======================= Other Surface Procedures ==========================
 
 to draw-surface
-  while [mouse-down?] [
+  if mouse-down? [
     create-turtles 1 [
       setxy mouse-xcor mouse-ycor
       ask patches in-radius 3 [ set pcolor violet ]


### PR DESCRIPTION
This pull request changes all uses of `while [mouse-down?] [...]` that I see in the library to be NetLogo Web compatible via forever buttons and global variables to track state as needed.

Track if `mouse-handled?` via global so we can avoid running multiple times if the user holds the button down:

- Sample Models/Biology/Evolution/Sunflower Biomorphs.nlogo:
- Sample Models/Chemistry & Physics/Mechanics/Unverified/N-Bodies.nlogo:

Straightforward switch to forever-button style:

- Sample Models/Chemistry & Physics/Waves/Lattice Gas Automaton.nlogo:
- Sample Models/Mathematics/Unverified/Surface Walking 2D.nlogo:

Need a global to track if the mouse operation started `erasing?` or not:

- Sample Models/Computer Science/Cellular Automata/Brian's Brain.nlogo:
- Sample Models/Computer Science/Cellular Automata/Life Turtle-Based.nlogo:
- Sample Models/Computer Science/Cellular Automata/Life.nlogo:

Track the initial `click-vertex` as a global to move it as the user drags:

- Sample Models/Mathematics/Unverified/PANDA BEAR Solo.nlogo:
