### PR TITLE
Update modes using bad intersection code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.9'
 
       - name: Install Dependencies
         run: |

--- a/Code Examples/Intersecting Lines Example.nlogo
+++ b/Code Examples/Intersecting Lines Example.nlogo
@@ -41,30 +41,38 @@ end
 ;; reports a two-item list of x and y coordinates, or an empty
 ;; list if no intersection is found
 to-report intersection [t1 t2]
-  let m1 [tan (90 - heading)] of t1
-  let m2 [tan (90 - heading)] of t2
-  ;; treat parallel/collinear lines as non-intersecting
-  if m1 = m2 [ report [] ]
+  let is-t1-vertical? ([heading] of t1 = 0 or [heading] of t1 = 180)
+  let is-t2-vertical? ([heading] of t2 = 0 or [heading] of t2 = 180)
+
   ;; is t1 vertical? if so, swap the two turtles
-  if abs m1 = tan 90
+  if is-t1-vertical?
   [
-    ifelse abs m2 = tan 90
+    ifelse is-t2-vertical?
       [ report [] ]
       [ report intersection t2 t1 ]
   ]
+
+  let m1 [tan (90 - heading)] of t1
+
   ;; is t2 vertical? if so, handle specially
-  if abs m2 = tan 90 [
-     ;; represent t1 line in slope-intercept form (y=mx+c)
-      let c1 [ycor - xcor * m1] of t1
-      ;; t2 is vertical so we know x already
-      let x [xcor] of t2
-      ;; solve for y
-      let y m1 * x + c1
-      ;; check if intersection point lies on both segments
-      if not [x-within? x] of t1 [ report [] ]
-      if not [y-within? y] of t2 [ report [] ]
-      report list x y
+  if is-t2-vertical? [
+    ;; represent t1 line in slope-intercept form (y=mx+c)
+    let c1 [ycor - xcor * m1] of t1
+    ;; t2 is vertical so we know x already
+    let x [xcor] of t2
+    ;; solve for y
+    let y m1 * x + c1
+    ;; check if intersection point lies on both segments
+    if not [x-within? x] of t1 [ report [] ]
+    if not [y-within? y] of t2 [ report [] ]
+    report list x y
   ]
+
+  let m2 [tan (90 - heading)] of t2
+
+  ;; treat parallel/collinear lines as non-intersecting
+  if m1 = m2 [ report [] ]
+
   ;; now handle the normal case where neither turtle is vertical;
   ;; start by representing lines in slope-intercept form (y=mx+c)
   let c1 [ycor - xcor * m1] of t1

--- a/Code Examples/Intersecting Links Example.nlogo
+++ b/Code Examples/Intersecting Links Example.nlogo
@@ -50,30 +50,38 @@ end
 ;; reports a two-item list of x and y coordinates, or an empty
 ;; list if no intersection is found
 to-report intersection [t1 t2]
-  let m1 [tan (90 - link-heading)] of t1
-  let m2 [tan (90 - link-heading)] of t2
-  ;; treat parallel/collinear lines as non-intersecting
-  if m1 = m2 [ report [] ]
+  let is-t1-vertical? ([link-heading] of t1 = 0 or [link-heading] of t1 = 180)
+  let is-t2-vertical? ([link-heading] of t2 = 0 or [link-heading] of t2 = 180)
+
   ;; is t1 vertical? if so, swap the two turtles
-  if abs m1 = tan 90
+  if is-t1-vertical?
   [
-    ifelse abs m2 = tan 90
+    ifelse is-t2-vertical?
       [ report [] ]
       [ report intersection t2 t1 ]
   ]
+
+  let m1 [tan (90 - link-heading)] of t1
+
   ;; is t2 vertical? if so, handle specially
-  if abs m2 = tan 90 [
-     ;; represent t1 line in slope-intercept form (y=mx+c)
-      let c1 [link-ycor - link-xcor * m1] of t1
-      ;; t2 is vertical so we know x already
-      let x [link-xcor] of t2
-      ;; solve for y
-      let y m1 * x + c1
-      ;; check if intersection point lies on both segments
-      if not [x-within? x] of t1 [ report [] ]
-      if not [y-within? y] of t2 [ report [] ]
-      report list x y
+  if is-t2-vertical? [
+    ;; represent t1 line in slope-intercept form (y=mx+c)
+    let c1 [link-ycor - link-xcor * m1] of t1
+    ;; t2 is vertical so we know x already
+    let x [link-xcor] of t2
+    ;; solve for y
+    let y m1 * x + c1
+    ;; check if intersection point lies on both segments
+    if not [x-within? x] of t1 [ report [] ]
+    if not [y-within? y] of t2 [ report [] ]
+    report list x y
   ]
+
+  let m2 [tan (90 - link-heading)] of t2
+
+  ;; treat parallel/collinear lines as non-intersecting
+  if m1 = m2 [ report [] ]
+
   ;; now handle the normal case where neither turtle is vertical;
   ;; start by representing lines in slope-intercept form (y=mx+c)
   let c1 [link-ycor - link-xcor * m1] of t1

--- a/Curricular Models/Lattice Land/Lattice Land - Explore.nlogo
+++ b/Curricular Models/Lattice Land/Lattice Land - Explore.nlogo
@@ -294,33 +294,41 @@ end
 
 ;  reports a two-item list of x and y coordinates, or an empty list if no intersection is found
 to-report intersection [ t1 t2 ]
-
   let shared-ends (shared-link-ends t1 t2)
   if (shared-ends != []) [ report shared-ends ]
 
-  let m1 [tan (90 - link-heading)] of t1
-  let m2 [tan (90 - link-heading)] of t2
-  ;  treat parallel/collinear lines as non-intersecting
-  if m1 = m2 [ report [] ]
+  let is-t1-vertical? ([link-heading] of t1 = 0 or [link-heading] of t1 = 180)
+  let is-t2-vertical? ([link-heading] of t2 = 0 or [link-heading] of t2 = 180)
+
   ;  is t1 vertical? if so, swap the two turtles
-  if abs m1 = tan 90 [
-    ifelse abs m2 = tan 90
+  if is-t1-vertical?
+  [
+    ifelse is-t2-vertical?
       [ report [] ]
       [ report intersection t2 t1 ]
   ]
+
+  let m1 [tan (90 - link-heading)] of t1
+
   ;  is t2 vertical? if so, handle specially
-  if abs m2 = tan 90 [
-      ;  represent t1 line in slope-intercept form (y=mx+c)
-      let c1 [ link-ycor - link-xcor * m1 ] of t1
-      ;  t2 is vertical so we know x already
-      let x [ link-xcor ] of t2
-      ;  solve for y
-      let y m1 * x + c1
-      ;  check if intersection point lies on both segments
-      if not [ x-within? x ] of t1 [ report [] ]
-      if not [ y-within? y ] of t2 [ report [] ]
-      report list x y
+  if is-t2-vertical? [
+    ;  represent t1 line in slope-intercept form (y=mx+c)
+    let c1 [ link-ycor - link-xcor * m1 ] of t1
+    ;  t2 is vertical so we know x already
+    let x [ link-xcor ] of t2
+    ;  solve for y
+    let y m1 * x + c1
+    ;  check if intersection point lies on both segments
+    if not [ x-within? x ] of t1 [ report [] ]
+    if not [ y-within? y ] of t2 [ report [] ]
+    report list x y
   ]
+
+  let m2 [tan (90 - link-heading)] of t2
+
+  ;  treat parallel/collinear lines as non-intersecting
+  if m1 = m2 [ report [] ]
+
   ;  now handle the normal case where neither turtle is vertical;
   ;  start by representing lines in slope-intercept form (y=mx+c)
   let c1 [ link-ycor - link-xcor * m1 ] of t1

--- a/test/Preferential Attachment Tester.nlogo
+++ b/test/Preferential Attachment Tester.nlogo
@@ -102,31 +102,41 @@ to-report bad-intersections [t1 t2]
   report true
 end
 
+;; reports a two-item list of x and y coordinates, or an empty
+;; list if no intersection is found
 to-report intersection [t1 t2]
-  let m1 [tan (90 - link-heading)] of t1
-  let m2 [tan (90 - link-heading)] of t2
-  ;; treat parallel/collinear lines as non-intersecting
-  if m1 = m2 [ report [] ]
+  let is-t1-vertical? ([link-heading] of t1 = 0 or [link-heading] of t1 = 180)
+  let is-t2-vertical? ([link-heading] of t2 = 0 or [link-heading] of t2 = 180)
+
   ;; is t1 vertical? if so, swap the two turtles
-  if abs m1 = tan 90
+  if is-t1-vertical?
   [
-    ifelse abs m2 = tan 90
+    ifelse is-t2-vertical?
       [ report [] ]
       [ report intersection t2 t1 ]
   ]
+
+  let m1 [tan (90 - link-heading)] of t1
+
   ;; is t2 vertical? if so, handle specially
-  if abs m2 = tan 90 [
-     ;; represent t1 line in slope-intercept form (y=mx+c)
-      let c1 [link-ycor - link-xcor * m1] of t1
-      ;; t2 is vertical so we know x already
-      let x [link-xcor] of t2
-      ;; solve for y
-      let y m1 * x + c1
-      ;; check if intersection point lies on both segments
-      if not [x-within? x] of t1 [ report [] ]
-      if not [y-within? y] of t2 [ report [] ]
-      report list x y
+  if is-t2-vertical? [
+    ;; represent t1 line in slope-intercept form (y=mx+c)
+    let c1 [link-ycor - link-xcor * m1] of t1
+    ;; t2 is vertical so we know x already
+    let x [link-xcor] of t2
+    ;; solve for y
+    let y m1 * x + c1
+    ;; check if intersection point lies on both segments
+    if not [x-within? x] of t1 [ report [] ]
+    if not [y-within? y] of t2 [ report [] ]
+    report list x y
   ]
+
+  let m2 [tan (90 - link-heading)] of t2
+
+  ;; treat parallel/collinear lines as non-intersecting
+  if m1 = m2 [ report [] ]
+
   ;; now handle the normal case where neither turtle is vertical;
   ;; start by representing lines in slope-intercept form (y=mx+c)
   let c1 [link-ycor - link-xcor * m1] of t1


### PR DESCRIPTION
These four models used a copy/pasted variant of the same code that treated `tan 90` as a real value that could be compared to in order to find vertical lines/links.  Due to a bug, `tan 90` did return a very large real number due to the inability of floating point numbers to exactly specify half of pi.  We want `tan 90` to now throw a runtime error in NetLogo, so we rework this code to avoid using it.

Also includes a small unrelated change to speed up build times by fixing the Python 3 version.
