### PR TITLE
Fix inaccurate comment in Small Worlds

### DIFF
--- a/Sample Models/Networks/Small Worlds.nlogo
+++ b/Sample Models/Networks/Small Worlds.nlogo
@@ -82,7 +82,7 @@ to rewire-one
 end
 
 
-to rewire-me ; turtle procedure
+to rewire-me ; link procedure
   ; node-A remains the same
   let node-A end1
   ; as long as A is not connected to everybody


### PR DESCRIPTION
The `rewire-me` procedure had a comment saying that it's a turtle procedure, but it's actually a link procedure.