### PR TITLE
Resize remaining art models

### DIFF
--- a/Sample Models/Art/GenJam - Duple.nlogox
+++ b/Sample Models/Art/GenJam - Duple.nlogox
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<model version="NetLogo 7.0.0-beta0" snapToGrid="true">
+<model version="NetLogo 7.0.0-beta1" snapToGrid="true">
   <code><![CDATA[extensions [ sound ]
 
 globals [
@@ -385,14 +385,42 @@ end
 ; Copyright 2017 Uri Wilensky.
 ; See Info tab for full copyright and license.]]></code>
   <widgets>
-    <view x="290" wrappingAllowedX="false" y="10" frameRate="30.0" minPycor="0" height="340" showTickCounter="true" patchSize="21.0" fontSize="10" wrappingAllowedY="false" width="340" tickCounterLabel="ticks" maxPycor="15" updateMode="1" maxPxcor="15" minPxcor="0"></view>
-    <button x="5" y="50" height="33" disableUntilTicks="false" forever="false" kind="Observer" display="setup" width="66" sizeVersion="0">setup
+    <view x="340" wrappingAllowedX="false" y="10" frameRate="30.0" minPycor="0" height="340" showTickCounter="true" patchSize="21.0" fontSize="10" wrappingAllowedY="false" width="340" tickCounterLabel="ticks" maxPycor="15" updateMode="1" maxPxcor="15" minPxcor="0"></view>
+    <slider x="5" step="1" y="10" max="12" width="170" display="num-chromosomes" height="50" min="2" direction="Horizontal" default="4.0" variable="num-chromosomes"></slider>
+    <button x="75" y="65" height="35" disableUntilTicks="true" forever="false" kind="Observer" width="135" display="go-once-no-evolve">repeat num-chromosomes * 4 [go-no-evolve]</button>
+    <button x="5" y="65" height="35" disableUntilTicks="false" forever="false" kind="Observer" width="66" display="setup">setup
 sound:play-note "TRUMPET" 60 62 2
 wait 2</button>
-    <button x="215" y="90" height="33" disableUntilTicks="true" forever="true" kind="Observer" display="go" width="70" sizeVersion="0">go</button>
-    <slider x="5" step="1" y="10" max="12" display="num-chromosomes" height="33" min="2" direction="Horizontal" default="4.0" variable="num-chromosomes" width="145" sizeVersion="0"></slider>
-    <switch x="155" y="10" height="33" on="true" variable="shuffle-parts?" display="shuffle-parts?" width="130" sizeVersion="0"></switch>
-    <plot x="545" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="Number of Hits" y="370" xMin="0.0" height="150" legend="false" xMax="16.0" yMin="0.0" xAxis="Drummer" display="Hits per Drummer (total)" width="235" sizeVersion="0">
+    <switch x="5" y="105" height="37" on="true" variable="sound?" width="95" display="sound?"></switch>
+    <button x="105" y="105" height="35" disableUntilTicks="true" forever="true" kind="Observer" width="105">go-no-evolve</button>
+    <slider x="5" step="1" y="200" max="200" width="150" display="hit-limit" height="50" min="50" direction="Horizontal" default="120.0" variable="hit-limit"></slider>
+    <slider x="5" step="1" y="255" max="10" width="150" display="num-mutations" height="50" min="1" direction="Horizontal" default="1.0" variable="num-mutations"></slider>
+    <slider x="160" step="0.01" y="200" max="1" width="170" display="hit-density-modifier" height="50" min="0" direction="Horizontal" default="0.5" variable="hit-density-modifier"></slider>
+    <slider x="160" step="1" y="255" max="8" width="170" display="mutation-strength" height="50" min="0" direction="Horizontal" default="1.0" variable="mutation-strength"></slider>
+    <switch x="180" y="10" height="50" on="true" variable="shuffle-parts?" width="150" display="shuffle-parts?"></switch>
+    <slider x="5" step="1" y="145" max="200" width="325" display="tempo-bpm" height="50" min="40" direction="Horizontal" default="135.0" variable="tempo-bpm"></slider>
+    <button x="215" y="65" height="35" disableUntilTicks="true" forever="false" kind="Observer" width="115" display="go-once">repeat num-chromosomes * 4 [ go ]</button>
+    <button x="215" y="105" height="35" disableUntilTicks="true" forever="true" kind="Observer" width="115" display="go">go</button>
+    <chooser x="55" y="310" height="60" variable="soloer" current="0" width="100" display="soloer">
+      <choice type="double" value="0.0"></choice>
+      <choice type="double" value="1.0"></choice>
+      <choice type="double" value="2.0"></choice>
+      <choice type="double" value="3.0"></choice>
+      <choice type="double" value="4.0"></choice>
+      <choice type="double" value="5.0"></choice>
+      <choice type="double" value="6.0"></choice>
+      <choice type="double" value="7.0"></choice>
+      <choice type="double" value="8.0"></choice>
+      <choice type="double" value="9.0"></choice>
+      <choice type="double" value="10.0"></choice>
+      <choice type="double" value="11.0"></choice>
+      <choice type="double" value="12.0"></choice>
+      <choice type="double" value="13.0"></choice>
+      <choice type="double" value="14.0"></choice>
+      <choice type="double" value="15.0"></choice>
+    </chooser>
+    <switch x="160" y="310" height="60" on="false" variable="solo?" width="100" display="solo?"></switch>
+    <plot x="550" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="Number of Hits" y="375" xMin="0.0" height="240" legend="false" xMax="16.0" yMin="0.0" width="315" xAxis="Drummer" display="Hits per Drummer (total)">
       <setup></setup>
       <update></update>
       <pen interval="1.0" mode="1" display="low" color="-2674135" legend="true">
@@ -411,7 +439,24 @@ ask med-drums [plotxy who hits]</update>
 ask high-drums [plotxy who hits]</update>
       </pen>
     </plot>
-    <plot x="5" autoPlotX="true" yMax="1.0" autoPlotY="true" yAxis="Fitness" y="370" xMin="0.0" height="150" legend="true" xMax="1.0" yMin="0.0" xAxis="Ticks" display="Average Fitness" width="280" sizeVersion="0">
+    <plot x="295" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="Number of Hits" y="375" xMin="0.0" height="240" legend="false" xMax="10.0" yMin="0.0" width="250" xAxis="Drummer" display="Hits Since Evolution">
+      <setup></setup>
+      <update></update>
+      <pen interval="1.0" mode="1" display="low" color="-2674135" legend="true">
+        <setup></setup>
+        <update>plot-pen-reset
+ask low-drums [ plotxy who hits-since-evolve ]</update>
+      </pen>
+      <pen interval="1.0" mode="1" display="pen-1" color="-10899396" legend="true">
+        <setup></setup>
+        <update>plot-pen-reset ask med-drums [ plotxy who hits-since-evolve ]</update>
+      </pen>
+      <pen interval="1.0" mode="1" display="pen-2" color="-13345367" legend="true">
+        <setup></setup>
+        <update>plot-pen-reset ask high-drums [ plotxy who hits-since-evolve ]</update>
+      </pen>
+    </plot>
+    <plot x="10" autoPlotX="true" yMax="1.0" autoPlotY="true" yAxis="Fitness" y="375" xMin="0.0" height="240" legend="true" xMax="1.0" yMin="0.0" width="280" xAxis="Ticks" display="Average Fitness">
       <setup></setup>
       <update></update>
       <pen interval="1.0" mode="0" display="all" color="-16777216" legend="true">
@@ -431,53 +476,8 @@ ask high-drums [plotxy who hits]</update>
         <update>plot mean [fitness] of high-drums</update>
       </pen>
     </plot>
-    <slider x="110" step="0.01" y="170" max="1" display="hit-density-modifier" height="33" min="0" direction="Horizontal" default="0.5" variable="hit-density-modifier" width="175" sizeVersion="0"></slider>
-    <switch x="5" y="90" height="33" on="true" variable="sound?" display="sound?" width="103" sizeVersion="0"></switch>
-    <slider x="5" step="1" y="210" max="10" display="num-mutations" height="33" min="1" direction="Horizontal" default="1.0" variable="num-mutations" width="125" sizeVersion="0"></slider>
-    <slider x="135" step="1" y="210" max="8" display="mutation-strength" height="33" min="0" direction="Horizontal" default="1.0" variable="mutation-strength" width="150" sizeVersion="0"></slider>
-    <chooser x="40" y="310" height="45" variable="soloer" current="0" display="soloer" width="92" sizeVersion="0">
-      <choice type="double" value="0.0"></choice>
-      <choice type="double" value="1.0"></choice>
-      <choice type="double" value="2.0"></choice>
-      <choice type="double" value="3.0"></choice>
-      <choice type="double" value="4.0"></choice>
-      <choice type="double" value="5.0"></choice>
-      <choice type="double" value="6.0"></choice>
-      <choice type="double" value="7.0"></choice>
-      <choice type="double" value="8.0"></choice>
-      <choice type="double" value="9.0"></choice>
-      <choice type="double" value="10.0"></choice>
-      <choice type="double" value="11.0"></choice>
-      <choice type="double" value="12.0"></choice>
-      <choice type="double" value="13.0"></choice>
-      <choice type="double" value="14.0"></choice>
-      <choice type="double" value="15.0"></choice>
-    </chooser>
-    <monitor x="40" precision="17" y="255" height="45" fontSize="11" width="90" sizeVersion="0">generations</monitor>
-    <button x="110" y="90" height="33" disableUntilTicks="true" forever="true" kind="Observer" width="100" sizeVersion="0">go-no-evolve</button>
-    <button x="75" y="50" height="33" disableUntilTicks="true" forever="false" kind="Observer" display="go-once-no-evolve" width="135" sizeVersion="0">repeat num-chromosomes * 4 [go-no-evolve]</button>
-    <button x="215" y="50" height="33" disableUntilTicks="true" forever="false" kind="Observer" display="go-once" width="70" sizeVersion="0">repeat num-chromosomes * 4 [ go ]</button>
-    <switch x="135" y="315" height="33" on="false" variable="solo?" display="solo?" width="103" sizeVersion="0"></switch>
-    <slider x="5" step="1" y="130" max="200" display="tempo-bpm" height="33" min="40" direction="Horizontal" default="135.0" variable="tempo-bpm" width="280" sizeVersion="0"></slider>
-    <monitor x="135" precision="17" y="255" height="45" fontSize="11" display="Density" width="87" sizeVersion="0">precision (count patches with [(pcolor != black) and (pcolor != yellow)] / (count patches)) 3</monitor>
-    <plot x="290" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="Number of Hits" y="370" xMin="0.0" height="150" legend="false" xMax="10.0" yMin="0.0" xAxis="Drummer" display="Hits Since Evolution" width="250" sizeVersion="0">
-      <setup></setup>
-      <update></update>
-      <pen interval="1.0" mode="1" display="low" color="-2674135" legend="true">
-        <setup></setup>
-        <update>plot-pen-reset
-ask low-drums [ plotxy who hits-since-evolve ]</update>
-      </pen>
-      <pen interval="1.0" mode="1" display="pen-1" color="-10899396" legend="true">
-        <setup></setup>
-        <update>plot-pen-reset ask med-drums [ plotxy who hits-since-evolve ]</update>
-      </pen>
-      <pen interval="1.0" mode="1" display="pen-2" color="-13345367" legend="true">
-        <setup></setup>
-        <update>plot-pen-reset ask high-drums [ plotxy who hits-since-evolve ]</update>
-      </pen>
-    </plot>
-    <slider x="5" step="1" y="170" max="200" display="hit-limit" height="33" min="50" direction="Horizontal" default="120.0" variable="hit-limit" width="100" sizeVersion="0"></slider>
+    <monitor x="690" precision="17" y="112" height="60" fontSize="11" width="100">generations</monitor>
+    <monitor x="690" precision="17" y="175" height="60" fontSize="11" width="100" display="density">precision (count patches with [(pcolor != black) and (pcolor != yellow)] / (count patches)) 3</monitor>
   </widgets>
   <info><![CDATA[## WHAT IS IT?
 
@@ -1472,7 +1472,7 @@ To inquire about commercial licenses for either NetLogo or specific models from 
     </shape>
   </linkShapes>
   <hubNetClient>
-    <view x="71" wrappingAllowedX="true" y="41" frameRate="30.0" minPycor="0" height="320" showTickCounter="true" patchSize="12.0" fontSize="13" wrappingAllowedY="true" width="560" tickCounterLabel="ticks" maxPycor="15" updateMode="1" maxPxcor="15" minPxcor="0"></view>
+    <view x="71" wrappingAllowedX="false" y="41" frameRate="30.0" minPycor="0" height="320" showTickCounter="true" patchSize="21.0" fontSize="13" wrappingAllowedY="false" width="560" tickCounterLabel="ticks" maxPycor="15" updateMode="1" maxPxcor="15" minPxcor="0"></view>
   </hubNetClient>
   <previewCommands>set sound? False
 set tempo-bpm 1000

--- a/Sample Models/Art/Kaleidoscope.nlogox
+++ b/Sample Models/Art/Kaleidoscope.nlogox
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<model version="NetLogo 7.0.0-beta0" snapToGrid="true">
+<model version="NetLogo 7.0.0-beta1" snapToGrid="true">
   <code><![CDATA[globals [ curr-color-sep ]   ; spread of the colors in the kaleidoscope
 
 ; INITIALIZATION PROCEDURES
@@ -86,15 +86,15 @@ end
 ; Copyright 1998 Uri Wilensky.
 ; See Info tab for full copyright and license.]]></code>
   <widgets>
-    <view x="295" wrappingAllowedX="false" y="10" frameRate="30.0" minPycor="-50" height="408" showTickCounter="true" patchSize="4.0" fontSize="10" wrappingAllowedY="false" width="408" tickCounterLabel="ticks" maxPycor="50" updateMode="1" maxPxcor="50" minPxcor="-50"></view>
-    <monitor x="75" precision="3" y="130" height="45" fontSize="11" display="current-color-sep" width="140" sizeVersion="0">curr-color-sep</monitor>
-    <slider x="145" step="1.0" y="10" max="60.0" display="color-sep" height="33" min="1.0" direction="Horizontal" default="1.0" variable="color-sep" width="140" sizeVersion="0"></slider>
-    <button x="5" y="50" height="33" disableUntilTicks="false" forever="false" kind="Observer" display="setup" width="80" sizeVersion="0">setup</button>
-    <button x="90" y="50" height="33" disableUntilTicks="true" forever="true" kind="Observer" display="pattern-1" width="93" sizeVersion="0">pattern-1</button>
-    <switch x="145" y="90" height="33" on="true" variable="increase-color?" display="increase-color?" width="140" sizeVersion="0"></switch>
-    <button x="190" y="50" height="33" disableUntilTicks="true" forever="true" kind="Observer" display="pattern-2" width="95" sizeVersion="0">pattern-2</button>
-    <slider x="5" step="1" y="10" max="24" display="num-turtles" height="33" min="1" direction="Horizontal" default="6.0" variable="num-turtles" width="135" sizeVersion="0"></slider>
-    <switch x="5" y="90" height="33" on="true" variable="color-shift?" display="color-shift?" width="136" sizeVersion="0"></switch>
+    <view x="310" wrappingAllowedX="false" y="7" frameRate="30.0" minPycor="-50" height="408" showTickCounter="true" patchSize="4.0" fontSize="10" wrappingAllowedY="false" width="408" tickCounterLabel="ticks" maxPycor="50" updateMode="1" maxPxcor="50" minPxcor="-50"></view>
+    <button x="5" y="60" height="35" disableUntilTicks="false" forever="false" kind="Observer" width="80" display="setup">setup</button>
+    <slider x="0" step="1" y="7" max="24" width="150" display="num-turtles" height="50" min="1" direction="Horizontal" default="6.0" variable="num-turtles"></slider>
+    <slider x="155" step="1.0" y="7" max="60.0" width="150" display="color-sep" height="50" min="1.0" direction="Horizontal" default="1.0" variable="color-sep"></slider>
+    <button x="200" y="60" height="35" disableUntilTicks="true" forever="true" kind="Observer" width="105" display="pattern-2">pattern-2</button>
+    <button x="90" y="60" height="35" disableUntilTicks="true" forever="true" kind="Observer" width="105" display="pattern-1">pattern-1</button>
+    <switch x="5" y="100" height="37" on="true" variable="color-shift?" width="145" display="color-shift?"></switch>
+    <switch x="155" y="100" height="37" on="true" variable="increase-color?" width="150" display="increase-color?"></switch>
+    <monitor x="85" precision="3" y="145" height="60" fontSize="11" width="140" display="current-color-sep">curr-color-sep</monitor>
   </widgets>
   <info><![CDATA[## WHAT IS IT?
 


### PR DESCRIPTION
Updates `Interface` tab of remaining `Sample Models/Art` to new NetLogo 7 styling / sizing.

## Other notes
* Enables `Snap to Grid` on all models

## Before and After

<table>
  <tr>
    <td><img style="width:50%;" alt="genjam-before" src="https://github.com/user-attachments/assets/4439179c-4f47-4bfc-bca0-d4d12dda94a7"  >
</td>
    <td><img style="width:50%;" alt="genjam-after" src="https://github.com/user-attachments/assets/e9c6907c-1a59-4b68-923b-704b60194322" ></td>
   </tr> 
  <tr>
    <td><img style="width:50%;" alt="kaleidoscope-before" src="https://github.com/user-attachments/assets/99cfbd5a-3f34-4f99-b232-7bb03cdadc77"  >
</td>
    <td><img style="width:50%;"  alt="kaleidoscope-after" src="https://github.com/user-attachments/assets/ff1a304f-719d-4b5e-849b-455d1f1cc9f0" ></td>
   </tr> 
</table>