### PR TITLE
Resize CRISPR Models

### DIFF
--- a/Sample Models/Biology/CRISPR/CRISPR Bacterium LevelSpace.nlogox
+++ b/Sample Models/Biology/CRISPR/CRISPR Bacterium LevelSpace.nlogox
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<model version="NetLogo 7.0.0-beta0" snapToGrid="true">
+<model version="NetLogo 7.0.0-beta1" snapToGrid="true">
   <code><![CDATA[globals [
   ; Housekeeping variables
   cell-wall  ; Patch-set containing cell wall patches for boundary checking
@@ -407,12 +407,23 @@ end
 ; Copyright 2019 Uri Wilensky.
 ; See Info tab for full copyright and license.]]></code>
   <widgets>
-    <view x="190" wrappingAllowedX="false" y="20" frameRate="30.0" minPycor="-8" height="327" showTickCounter="true" patchSize="19.0" fontSize="10" wrappingAllowedY="false" width="631" tickCounterLabel="ticks" maxPycor="8" updateMode="1" maxPxcor="16" minPxcor="-16"></view>
-    <button x="20" y="20" height="40" disableUntilTicks="false" forever="false" kind="Observer" display="setup" width="80" sizeVersion="0">setup n-values initial-array-size [random max-virus-types] guide-unbind-chance processivity crispr-function</button>
-    <button x="110" y="20" height="40" disableUntilTicks="true" forever="true" kind="Observer" width="70" sizeVersion="0">go</button>
-    <monitor x="430" precision="17" y="505" height="45" fontSize="11" display="Viruses" width="70" sizeVersion="0">count viruses</monitor>
-    <monitor x="775" precision="17" y="505" height="45" fontSize="11" display="Length" width="50" sizeVersion="0">length array</monitor>
-    <plot x="190" autoPlotX="true" yMax="10.0" autoPlotY="true" y="355" xMin="0.0" height="140" legend="true" xMax="10.0" yMin="0.0" display="CRISPR Elements" width="310" sizeVersion="0">
+    <view x="200" wrappingAllowedX="false" y="7" frameRate="30.0" minPycor="-8" height="327" showTickCounter="true" patchSize="19.0" fontSize="10" wrappingAllowedY="false" width="631" tickCounterLabel="ticks" maxPycor="8" updateMode="1" maxPxcor="16" minPxcor="-16"></view>
+    <button x="5" y="5" height="40" disableUntilTicks="false" forever="false" kind="Observer" width="80" display="setup">setup n-values initial-array-size [random max-virus-types] guide-unbind-chance processivity crispr-function</button>
+    <button x="5" y="55" height="45" disableUntilTicks="true" forever="false" kind="Observer" width="190">common-infection</button>
+    <button x="95" y="5" height="40" disableUntilTicks="true" forever="true" kind="Observer" width="100">go</button>
+    <button x="5" y="110" height="45" disableUntilTicks="true" forever="false" kind="Observer" width="190" display="random-infection">infect random max-virus-types</button>
+    <switch x="5" y="160" height="37" on="false" variable="labels?" width="190" display="labels?"></switch>
+    <note x="5" y="200" backgroundDark="0" fontSize="12" width="190" markdown="false" height="90" textColorDark="-1" textColorLight="-16777216" backgroundLight="0">Even after a successful
+infection, turn labels on
+and off by toggling
+the switch and
+pressing go.</note>
+    <slider x="5" step="1" y="290" max="30" width="190" display="initial-array-size" height="50" min="1" direction="Horizontal" default="15.0" variable="initial-array-size"></slider>
+    <slider x="5" step="1" y="345" max="100" width="190" display="max-virus-types" height="50" min="1" direction="Horizontal" default="30.0" variable="max-virus-types"></slider>
+    <slider x="5" step="1" y="400" max="10" width="190" display="guide-unbind-chance" height="50" min="0" direction="Horizontal" default="5.0" variable="guide-unbind-chance" units="%"></slider>
+    <slider x="5" step="1" y="455" max="100" width="190" display="processivity" height="50" min="0" direction="Horizontal" default="80.0" variable="processivity" units="%"></slider>
+    <slider x="5" step="1" y="510" max="100" width="190" display="CRISPR-function" height="50" min="0" direction="Horizontal" default="100.0" variable="CRISPR-function" units="%"></slider>
+    <plot x="200" autoPlotX="true" yMax="10.0" autoPlotY="true" y="340" xMin="0.0" height="195" legend="true" xMax="10.0" yMin="0.0" width="310" display="CRISPR Elements">
       <setup></setup>
       <update></update>
       <pen interval="1.0" mode="0" display="Guide RNAs" color="-10899396" legend="true">
@@ -432,7 +443,15 @@ end
         <update>plot count cas-dimers</update>
       </pen>
     </plot>
-    <plot x="520" autoPlotX="true" yMax="10.0" autoPlotY="true" y="355" xMin="0.0" height="140" legend="true" xMax="10.0" yMin="0.0" display="Guide RNAs" width="305" sizeVersion="0">
+    <monitor x="200" precision="17" y="540" height="60" fontSize="11" width="100" display="Guide RNAs">count guide-rnas</monitor>
+    <monitor x="305" precision="17" y="540" height="60" fontSize="11" width="100" display="Cas9s">count cas9s</monitor>
+    <monitor x="410" precision="17" y="540" height="60" fontSize="11" width="100" display="Cas1/2s">count cas-dimers</monitor>
+    <note x="55" y="605" backgroundDark="0" fontSize="12" width="175" markdown="false" height="70" textColorDark="-1" textColorLight="-16777216" backgroundLight="0">The virus event monitor
+shows what interactions
+are taking place.</note>
+    <monitor x="360" precision="17" y="605" height="60" fontSize="11" width="100" display="Viruses">count viruses</monitor>
+    <monitor x="200" precision="17" y="605" height="60" fontSize="11" width="155" display="Virus event monitor">virus-event</monitor>
+    <plot x="515" autoPlotX="true" yMax="10.0" autoPlotY="true" y="340" xMin="0.0" height="195" legend="true" xMax="10.0" yMin="0.0" width="320" display="Guide RNAs">
       <setup>set-plot-x-range 0 max-virus-types</setup>
       <update>update-histogram-ranges sentence ([sequence] of guide-RNAs) (array) 1</update>
       <pen interval="1.0" mode="1" display="RNAs" color="-16777216" legend="true">
@@ -444,28 +463,9 @@ end
         <update>histogram array</update>
       </pen>
     </plot>
-    <slider x="20" step="1" y="300" max="30" display="initial-array-size" height="33" min="1" direction="Horizontal" default="15.0" variable="initial-array-size" width="160" sizeVersion="0"></slider>
-    <slider x="20" step="1" y="345" max="100" display="max-virus-types" height="33" min="1" direction="Horizontal" default="30.0" variable="max-virus-types" width="160" sizeVersion="0"></slider>
-    <monitor x="520" precision="17" y="505" height="45" fontSize="11" display="Bacterial CRISPR Array" width="245" sizeVersion="0">array</monitor>
-    <monitor x="190" precision="17" y="505" height="45" fontSize="11" display="Guide RNAs" width="70" sizeVersion="0">count guide-rnas</monitor>
-    <monitor x="270" precision="17" y="505" height="45" fontSize="11" display="Cas9s" width="70" sizeVersion="0">count cas9s</monitor>
-    <monitor x="350" precision="17" y="505" height="45" fontSize="11" display="Cas1/2s" width="70" sizeVersion="0">count cas-dimers</monitor>
-    <slider x="20" step="1" y="435" max="100" display="processivity" height="33" min="0" direction="Horizontal" default="80.0" variable="processivity" units="%" width="160" sizeVersion="0"></slider>
-    <slider x="20" step="1" y="480" max="100" display="CRISPR-function" height="33" min="0" direction="Horizontal" default="100.0" variable="CRISPR-function" units="%" width="160" sizeVersion="0"></slider>
-    <button x="20" y="70" height="45" disableUntilTicks="true" forever="false" kind="Observer" width="160" sizeVersion="0">common-infection</button>
-    <button x="20" y="125" height="45" disableUntilTicks="true" forever="false" kind="Observer" display="random-infection" width="160" sizeVersion="0">infect random max-virus-types</button>
-    <monitor x="520" precision="17" y="560" height="45" fontSize="11" display="Viral sequences" width="305" sizeVersion="0">sort [sequence] of viruses</monitor>
-    <switch x="20" y="180" height="33" on="false" variable="labels?" display="labels?" width="160" sizeVersion="0"></switch>
-    <monitor x="190" precision="17" y="560" height="45" fontSize="11" display="Virus event monitor" width="310" sizeVersion="0">virus-event</monitor>
-    <slider x="20" step="1" y="390" max="10" display="guide-unbind-chance" height="33" min="0" direction="Horizontal" default="5.0" variable="guide-unbind-chance" units="%" width="160" sizeVersion="0"></slider>
-    <note x="20" y="220" height="75" backgroundDark="0" fontSize="12" width="165" markdown="false" textColorLight="-16777216" backgroundLight="0">Even after a successful
-infection, turn labels on
-and off by toggling
-the switch and
-pressing go.</note>
-    <note x="25" y="555" height="70" backgroundDark="0" fontSize="12" width="175" markdown="false" textColorLight="-16777216" backgroundLight="0">The virus event monitor
-shows what interactions
-are taking place.</note>
+    <monitor x="735" precision="17" y="540" height="60" fontSize="11" width="100" display="Length">length array</monitor>
+    <monitor x="515" precision="17" y="540" height="60" fontSize="11" width="215" display="Bacterial CRISPR Array">array</monitor>
+    <monitor x="515" precision="17" y="605" height="60" fontSize="11" width="320" display="Viral sequences">sort [sequence] of viruses</monitor>
   </widgets>
   <info><![CDATA[## WHAT IS IT?
 

--- a/Sample Models/Biology/CRISPR/CRISPR Bacterium.nlogox
+++ b/Sample Models/Biology/CRISPR/CRISPR Bacterium.nlogox
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<model version="NetLogo 7.0.0-beta0" snapToGrid="true">
+<model version="NetLogo 7.0.0-beta1" snapToGrid="true">
   <code><![CDATA[globals [
   ; Housekeeping variables
   cell-wall  ; Patch-set containing cell wall patches for boundary checking
@@ -387,12 +387,22 @@ end
 ; Copyright 2019 Uri Wilensky.
 ; See Info tab for full copyright and license.]]></code>
   <widgets>
-    <view x="190" wrappingAllowedX="false" y="20" frameRate="30.0" minPycor="-8" height="327" showTickCounter="true" patchSize="19.0" fontSize="10" wrappingAllowedY="false" width="631" tickCounterLabel="ticks" maxPycor="8" updateMode="1" maxPxcor="16" minPxcor="-16"></view>
-    <button x="20" y="20" height="40" disableUntilTicks="false" forever="false" kind="Observer" width="80" sizeVersion="0">setup</button>
-    <button x="110" y="20" height="40" disableUntilTicks="true" forever="true" kind="Observer" width="70" sizeVersion="0">go</button>
-    <monitor x="430" precision="17" y="505" height="45" fontSize="11" display="Viruses" width="70" sizeVersion="0">count viruses</monitor>
-    <monitor x="775" precision="17" y="505" height="45" fontSize="11" display="Length" width="50" sizeVersion="0">length array</monitor>
-    <plot x="190" autoPlotX="true" yMax="10.0" autoPlotY="true" y="355" xMin="0.0" height="140" legend="true" xMax="10.0" yMin="0.0" display="CRISPR System Elements" width="310" sizeVersion="0">
+    <view x="205" wrappingAllowedX="false" y="7" frameRate="30.0" minPycor="-8" height="327" showTickCounter="true" patchSize="19.0" fontSize="10" wrappingAllowedY="false" width="631" tickCounterLabel="ticks" maxPycor="8" updateMode="1" maxPxcor="16" minPxcor="-16"></view>
+    <button x="5" y="7" height="40" disableUntilTicks="false" forever="false" kind="Observer" width="80">setup</button>
+    <slider x="5" step="1" y="285" max="30" width="195" display="initial-array-size" height="50" min="1" direction="Horizontal" default="15.0" variable="initial-array-size"></slider>
+    <slider x="5" step="1" y="340" max="100" width="195" display="max-virus-types" height="50" min="1" direction="Horizontal" default="30.0" variable="max-virus-types"></slider>
+    <switch x="5" y="155" height="37" on="false" variable="labels?" width="195" display="labels?"></switch>
+    <note x="5" y="195" backgroundDark="0" fontSize="12" width="195" markdown="false" height="86" textColorDark="-1" textColorLight="-16777216" backgroundLight="0">Even after a successful
+infection, turn labels on
+and off by toggling
+the switch and
+pressing go.</note>
+    <button x="5" y="105" height="45" disableUntilTicks="true" forever="false" kind="Observer" width="195" display="random-infection">infect random max-virus-types</button>
+    <button x="5" y="55" height="45" disableUntilTicks="true" forever="false" kind="Observer" width="195">common-infection</button>
+    <slider x="5" step="1" y="395" max="10" width="195" display="guide-unbind-chance" height="50" min="0" direction="Horizontal" default="5.0" variable="guide-unbind-chance" units="%"></slider>
+    <slider x="5" step="1" y="450" max="100" width="195" display="processivity" height="50" min="0" direction="Horizontal" default="80.0" variable="processivity" units="%"></slider>
+    <slider x="5" step="1" y="505" max="100" width="195" display="crispr-function" height="50" min="0" direction="Horizontal" default="20.0" variable="crispr-function" units="%"></slider>
+    <plot x="205" autoPlotX="true" yMax="10.0" autoPlotY="true" y="340" xMin="0.0" height="185" legend="true" xMax="10.0" yMin="0.0" width="310" display="CRISPR System Elements">
       <setup></setup>
       <update></update>
       <pen interval="1.0" mode="0" display="Guide RNAs" color="-10899396" legend="true">
@@ -412,7 +422,12 @@ end
         <update>plot count cas-dimers</update>
       </pen>
     </plot>
-    <plot x="520" autoPlotX="true" yMax="10.0" autoPlotY="true" y="355" xMin="0.0" height="140" legend="true" xMax="10.0" yMin="0.0" display="Guide RNAs" width="305" sizeVersion="0">
+    <monitor x="205" precision="17" y="530" height="60" fontSize="11" width="100" display="Guide RNAs">count guide-rnas</monitor>
+    <monitor x="205" precision="17" y="595" height="60" fontSize="11" width="140" display="Virus event monitor">virus-event</monitor>
+    <note x="60" y="595" backgroundDark="0" fontSize="12" width="170" markdown="false" height="60" textColorDark="-1" textColorLight="-16777216" backgroundLight="0">The virus event monitor
+shows what interactions
+are taking place.</note>
+    <plot x="520" autoPlotX="true" yMax="10.0" autoPlotY="true" y="340" xMin="0.0" height="185" legend="true" xMax="10.0" yMin="0.0" width="315" display="Guide RNAs">
       <setup>set-plot-x-range 0 max-virus-types</setup>
       <update>update-histogram-ranges sentence ([sequence] of guide-rnas) (array) 1</update>
       <pen interval="1.0" mode="1" display="RNAs" color="-16777216" legend="true">
@@ -424,28 +439,13 @@ end
         <update>histogram array</update>
       </pen>
     </plot>
-    <slider x="20" step="1" y="300" max="30" display="initial-array-size" height="33" min="1" direction="Horizontal" default="15.0" variable="initial-array-size" width="160" sizeVersion="0"></slider>
-    <slider x="20" step="1" y="345" max="100" display="max-virus-types" height="33" min="1" direction="Horizontal" default="30.0" variable="max-virus-types" width="160" sizeVersion="0"></slider>
-    <monitor x="520" precision="17" y="505" height="45" fontSize="11" display="Bacterial CRISPR Array" width="245" sizeVersion="0">array</monitor>
-    <monitor x="190" precision="17" y="505" height="45" fontSize="11" display="Guide RNAs" width="70" sizeVersion="0">count guide-rnas</monitor>
-    <monitor x="270" precision="17" y="505" height="45" fontSize="11" display="Cas9s" width="70" sizeVersion="0">count cas9s</monitor>
-    <monitor x="350" precision="17" y="505" height="45" fontSize="11" display="Cas1/2s" width="70" sizeVersion="0">count cas-dimers</monitor>
-    <slider x="20" step="1" y="435" max="100" display="processivity" height="33" min="0" direction="Horizontal" default="80.0" variable="processivity" units="%" width="160" sizeVersion="0"></slider>
-    <slider x="20" step="1" y="480" max="100" display="crispr-function" height="33" min="0" direction="Horizontal" default="20.0" variable="crispr-function" units="%" width="160" sizeVersion="0"></slider>
-    <button x="20" y="70" height="45" disableUntilTicks="true" forever="false" kind="Observer" width="160" sizeVersion="0">common-infection</button>
-    <button x="20" y="125" height="45" disableUntilTicks="true" forever="false" kind="Observer" display="random-infection" width="160" sizeVersion="0">infect random max-virus-types</button>
-    <monitor x="520" precision="17" y="560" height="45" fontSize="11" display="Viral sequences" width="305" sizeVersion="0">sort [sequence] of viruses</monitor>
-    <switch x="20" y="180" height="33" on="false" variable="labels?" display="labels?" width="160" sizeVersion="0"></switch>
-    <monitor x="190" precision="17" y="560" height="45" fontSize="11" display="Virus event monitor" width="310" sizeVersion="0">virus-event</monitor>
-    <slider x="20" step="1" y="390" max="10" display="guide-unbind-chance" height="33" min="0" direction="Horizontal" default="5.0" variable="guide-unbind-chance" units="%" width="160" sizeVersion="0"></slider>
-    <note x="20" y="220" height="86" backgroundDark="0" fontSize="12" width="185" markdown="false" textColorLight="-16777216" backgroundLight="0">Even after a successful
-infection, turn labels on
-and off by toggling
-the switch and
-pressing go.</note>
-    <note x="20" y="555" height="60" backgroundDark="0" fontSize="12" width="170" markdown="false" textColorLight="-16777216" backgroundLight="0">The virus event monitor
-shows what interactions
-are taking place.</note>
+    <monitor x="415" precision="17" y="530" height="60" fontSize="11" width="100" display="Cas1/2s">count cas-dimers</monitor>
+    <monitor x="310" precision="17" y="530" height="60" fontSize="11" width="100" display="Cas9s">count cas9s</monitor>
+    <monitor x="365" precision="17" y="595" height="60" fontSize="11" width="100" display="Viruses">count viruses</monitor>
+    <monitor x="735" precision="17" y="530" height="60" fontSize="11" width="100" display="Length">length array</monitor>
+    <monitor x="520" precision="17" y="530" height="60" fontSize="11" width="210" display="Bacterial CRISPR Array">array</monitor>
+    <monitor x="520" precision="17" y="595" height="60" fontSize="11" width="315" display="Viral sequences">sort [sequence] of viruses</monitor>
+    <button x="90" y="7" height="40" disableUntilTicks="true" forever="true" kind="Observer" width="110">go</button>
   </widgets>
   <info><![CDATA[## WHAT IS IT?
 

--- a/Sample Models/Biology/CRISPR/CRISPR Ecosystem LevelSpace.nlogox
+++ b/Sample Models/Biology/CRISPR/CRISPR Ecosystem LevelSpace.nlogox
@@ -321,12 +321,40 @@ end
 ; Copyright 2019 Uri Wilensky.
 ; See Info tab for full copyright and license.]]></code>
   <widgets>
-    <view x="810" wrappingAllowedX="true" y="15" frameRate="30.0" minPycor="-16" height="466" showTickCounter="true" patchSize="14.0" fontSize="10" wrappingAllowedY="true" width="466" tickCounterLabel="ticks" maxPycor="16" updateMode="1" maxPxcor="16" minPxcor="-16"></view>
-    <slider x="100" step="1" y="15" max="100" display="initial-bacteria" height="33" min="0" direction="Horizontal" default="50.0" variable="initial-bacteria" width="145" sizeVersion="0"></slider>
-    <slider x="100" step="10" y="60" max="1000" display="initial-viruses" height="33" min="0" direction="Horizontal" default="250.0" variable="initial-viruses" width="145" sizeVersion="0"></slider>
-    <button x="15" y="15" height="33" disableUntilTicks="false" forever="false" kind="Observer" width="75" sizeVersion="0">setup</button>
-    <button x="15" y="60" height="33" disableUntilTicks="true" forever="true" kind="Observer" width="75" sizeVersion="0">go</button>
-    <plot x="15" autoPlotX="true" yMax="10.0" autoPlotY="true" y="105" xMin="0.0" height="175" legend="true" xMax="10.0" yMin="0.0" display="Microbe Populations" width="250" sizeVersion="0">
+    <view x="815" wrappingAllowedX="true" y="7" frameRate="30.0" minPycor="-16" height="466" showTickCounter="true" patchSize="14.0" fontSize="10" wrappingAllowedY="true" width="466" tickCounterLabel="ticks" maxPycor="16" updateMode="1" maxPxcor="16" minPxcor="-16"></view>
+    <slider x="240" step="0.1" y="60" max="10" width="165" display="infection-chance" height="50" min="0" direction="Horizontal" default="5.0" variable="infection-chance" units="%"></slider>
+    <slider x="85" step="10" y="60" max="1000" width="150" display="initial-viruses" height="50" min="0" direction="Horizontal" default="250.0" variable="initial-viruses"></slider>
+    <button x="5" y="60" height="50" disableUntilTicks="true" forever="true" kind="Observer" width="75">go</button>
+    <slider x="240" step="1" y="7" max="100" width="165" display="max-virus-types" height="50" min="1" direction="Horizontal" default="50.0" variable="max-virus-types"></slider>
+    <slider x="85" step="1" y="7" max="100" width="150" display="initial-bacteria" height="50" min="0" direction="Horizontal" default="50.0" variable="initial-bacteria"></slider>
+    <button x="5" y="7" height="50" disableUntilTicks="false" forever="false" kind="Observer" width="75">setup</button>
+    <slider x="5" step="0.1" y="115" max="2" width="230" display="spacer-loss-chance" height="50" min="0" direction="Horizontal" default="1.0" variable="spacer-loss-chance" units="%"></slider>
+    <switch x="275" y="115" height="50" on="true" variable="crispr?" width="85" display="crispr?"></switch>
+    <plot x="575" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="% Abundance" y="7" xMin="0.0" height="240" legend="true" xMax="10.0" yMin="0.0" width="235" display="CRISPR-Virus Coevolution">
+      <setup></setup>
+      <update></update>
+      <pen interval="1.0" mode="0" display="Viruses" color="-16777216" legend="true">
+        <setup></setup>
+        <update>plot 100 * (count viruses with [sequence = plot-virus]) / (max list 1 count viruses)</update>
+      </pen>
+      <pen interval="1.0" mode="0" display="Arrays" color="-2674135" legend="true">
+        <setup></setup>
+        <update><![CDATA[let total-arrays reduce sentence [array] of bacteria
+let virus-instances filter [ i -> i = plot-virus ] total-arrays
+plot 100 * length virus-instances / (max list 1 length total-arrays)]]></update>
+      </pen>
+    </plot>
+    <plot x="575" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="Frequency" y="320" xMin="0.0" height="195" legend="false" xMax="10.0" yMin="0.0" width="235" xAxis="Array Length" display="Array Histogram">
+      <setup></setup>
+      <update>update-histogram-ranges ([ length array ] of bacteria) 1</update>
+      <pen interval="1.0" mode="1" display="default" color="-16777216" legend="true">
+        <setup></setup>
+        <update>histogram [ length array ] of bacteria</update>
+      </pen>
+    </plot>
+    <monitor x="710" precision="2" y="255" height="60" fontSize="11" width="100" display="Std. Dev.">standard-deviation [length array] of bacteria</monitor>
+    <monitor x="575" precision="2" y="255" height="60" fontSize="11" width="130" display="Avg. Array Length">mean [length array] of bacteria</monitor>
+    <plot x="5" autoPlotX="true" yMax="10.0" autoPlotY="true" y="175" xMin="0.0" height="220" legend="true" xMax="10.0" yMin="0.0" width="280" display="Microbe Populations">
       <setup></setup>
       <update><![CDATA[; Don't scroll until the end of an autoscale window.
 if ticks > 715
@@ -344,7 +372,7 @@ if ticks > 715
         <update>plot count viruses</update>
       </pen>
     </plot>
-    <plot x="15" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="% Abundance" y="290" xMin="0.0" height="195" legend="false" xMax="10.0" yMin="0.0" xAxis="Ticks" display="Virus Relative Abundance" width="540" sizeVersion="0">
+    <plot x="5" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="% Abundance" y="400" xMin="0.0" height="195" legend="false" xMax="10.0" yMin="0.0" width="565" xAxis="Ticks" display="Virus Relative Abundance">
       <setup></setup>
       <update><![CDATA[; Don't scroll until the end of an autoscale window.
 if ticks > 715
@@ -354,18 +382,7 @@ if ticks > 715
   set-plot-x-range (ticks - 715) ticks
 ]]]></update>
     </plot>
-    <slider x="255" step="0.1" y="60" max="10" display="infection-chance" height="33" min="0" direction="Horizontal" default="5.0" variable="infection-chance" units="%" width="145" sizeVersion="0"></slider>
-    <slider x="255" step="1" y="15" max="100" display="max-virus-types" height="33" min="1" direction="Horizontal" default="50.0" variable="max-virus-types" width="145" sizeVersion="0"></slider>
-    <monitor x="590" precision="2" y="255" height="45" fontSize="11" display="Avg. Array Length" width="105" sizeVersion="0">mean [length array] of bacteria</monitor>
-    <plot x="565" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="Frequency" y="310" xMin="0.0" height="175" legend="false" xMax="10.0" yMin="0.0" xAxis="Array Length" display="Array Histogram" width="235" sizeVersion="0">
-      <setup></setup>
-      <update>update-histogram-ranges ([ length array ] of bacteria) 1</update>
-      <pen interval="1.0" mode="1" display="default" color="-16777216" legend="true">
-        <setup></setup>
-        <update>histogram [ length array ] of bacteria</update>
-      </pen>
-    </plot>
-    <plot x="275" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="Frequency" y="105" xMin="0.0" height="175" legend="true" xMax="10.0" yMin="0.0" xAxis="Sequence ID" display="Sequence Histogram" width="280" sizeVersion="0">
+    <plot x="290" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="Frequency" y="175" xMin="0.0" height="220" legend="true" xMax="10.0" yMin="0.0" width="280" xAxis="Sequence ID" display="Sequence Histogram">
       <setup></setup>
       <update>update-histogram-ranges sentence ([sequence] of viruses) (ifelse-value empty? [array] of bacteria [ [] ] [ reduce sentence [array] of bacteria ]) 1</update>
       <pen interval="1.0" mode="1" display="Viruses" color="-16777216" legend="true">
@@ -377,27 +394,10 @@ if ticks > 715
         <update>histogram (ifelse-value empty? [array] of bacteria [ [] ] [ reduce sentence [array] of bacteria ])</update>
       </pen>
     </plot>
-    <slider x="410" step="0.1" y="15" max="2" display="spacer-loss-chance" height="33" min="0" direction="Horizontal" default="1.0" variable="spacer-loss-chance" units="%" width="145" sizeVersion="0"></slider>
-    <monitor x="705" precision="2" y="255" height="45" fontSize="11" display="Std. Dev." width="75" sizeVersion="0">standard-deviation [length array] of bacteria</monitor>
-    <switch x="410" y="60" height="33" on="true" variable="crispr?" display="crispr?" width="145" sizeVersion="0"></switch>
-    <plot x="565" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="% Abundance" y="15" xMin="0.0" height="185" legend="true" xMax="10.0" yMin="0.0" display="CRISPR-Virus Coevolution" width="235" sizeVersion="0">
-      <setup></setup>
-      <update></update>
-      <pen interval="1.0" mode="0" display="Viruses" color="-16777216" legend="true">
-        <setup></setup>
-        <update>plot 100 * (count viruses with [sequence = plot-virus]) / (max list 1 count viruses)</update>
-      </pen>
-      <pen interval="1.0" mode="0" display="Arrays" color="-2674135" legend="true">
-        <setup></setup>
-        <update><![CDATA[let total-arrays reduce sentence [array] of bacteria
-let virus-instances filter [ i -> i = plot-virus ] total-arrays
-plot 100 * length virus-instances / (max list 1 length total-arrays)]]></update>
-      </pen>
-    </plot>
-    <button x="565" y="210" height="33" disableUntilTicks="false" forever="false" kind="Observer" display="plot-new-virus" width="95" sizeVersion="0">set-current-plot "CRISPR-Virus Coevolution"
+    <button x="420" y="47" height="50" disableUntilTicks="false" forever="false" kind="Observer" width="150" display="plot-new-virus">set-current-plot "CRISPR-Virus Coevolution"
 clear-plot
 set plot-virus plotted-virus</button>
-    <slider x="670" step="1" y="210" max="max-virus-types - 1" display="plotted-virus" height="33" min="0" direction="Horizontal" default="35.0" variable="plotted-virus" width="130" sizeVersion="0"></slider>
+    <slider x="420" step="1" y="100" max="max-virus-types - 1" width="150" display="plotted-virus" height="50" min="0" direction="Horizontal" default="35.0" variable="plotted-virus"></slider>
   </widgets>
   <info><![CDATA[## WHAT IS IT?
 

--- a/Sample Models/Biology/CRISPR/CRISPR Ecosystem.nlogox
+++ b/Sample Models/Biology/CRISPR/CRISPR Ecosystem.nlogox
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<model version="NetLogo 7.0.0-beta0" snapToGrid="true">
+<model version="NetLogo 7.0.0-beta1" snapToGrid="true">
   <code><![CDATA[globals [
   food-color                     ; Color of food.
   bacteria-color                 ; Color of bacteria.
@@ -330,12 +330,40 @@ end
 ; Copyright 2019 Uri Wilensky.
 ; See Info tab for full copyright and license.]]></code>
   <widgets>
-    <view x="810" wrappingAllowedX="true" y="15" frameRate="30.0" minPycor="-16" height="466" showTickCounter="true" patchSize="14.0" fontSize="10" wrappingAllowedY="true" width="466" tickCounterLabel="ticks" maxPycor="16" updateMode="1" maxPxcor="16" minPxcor="-16"></view>
-    <slider x="100" step="1" y="15" max="100" display="initial-bacteria" height="33" min="0" direction="Horizontal" default="50.0" variable="initial-bacteria" width="145" sizeVersion="0"></slider>
-    <slider x="100" step="10" y="60" max="1000" display="initial-viruses" height="33" min="0" direction="Horizontal" default="250.0" variable="initial-viruses" width="145" sizeVersion="0"></slider>
-    <button x="15" y="15" height="33" disableUntilTicks="false" forever="false" kind="Observer" width="75" sizeVersion="0">setup</button>
-    <button x="15" y="60" height="33" disableUntilTicks="true" forever="true" kind="Observer" width="75" sizeVersion="0">go</button>
-    <plot x="15" autoPlotX="true" yMax="10.0" autoPlotY="true" y="105" xMin="0.0" height="175" legend="true" xMax="10.0" yMin="0.0" display="Microbe Populations" width="250" sizeVersion="0">
+    <view x="815" wrappingAllowedX="true" y="7" frameRate="30.0" minPycor="-16" height="466" showTickCounter="true" patchSize="14.0" fontSize="10" wrappingAllowedY="true" width="466" tickCounterLabel="ticks" maxPycor="16" updateMode="1" maxPxcor="16" minPxcor="-16"></view>
+    <slider x="240" step="0.1" y="60" max="10" width="165" display="infection-chance" height="50" min="0" direction="Horizontal" default="5.0" variable="infection-chance" units="%"></slider>
+    <slider x="85" step="10" y="60" max="1000" width="150" display="initial-viruses" height="50" min="0" direction="Horizontal" default="250.0" variable="initial-viruses"></slider>
+    <button x="5" y="60" height="50" disableUntilTicks="true" forever="true" kind="Observer" width="75">go</button>
+    <slider x="240" step="1" y="7" max="100" width="165" display="max-virus-types" height="50" min="1" direction="Horizontal" default="50.0" variable="max-virus-types"></slider>
+    <slider x="85" step="1" y="7" max="100" width="150" display="initial-bacteria" height="50" min="0" direction="Horizontal" default="50.0" variable="initial-bacteria"></slider>
+    <button x="5" y="7" height="50" disableUntilTicks="false" forever="false" kind="Observer" width="75">setup</button>
+    <slider x="5" step="0.1" y="115" max="2" width="230" display="spacer-loss-chance" height="50" min="0" direction="Horizontal" default="1.0" variable="spacer-loss-chance" units="%"></slider>
+    <switch x="275" y="115" height="50" on="true" variable="crispr?" width="85" display="crispr?"></switch>
+    <plot x="575" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="% Abundance" y="7" xMin="0.0" height="240" legend="true" xMax="10.0" yMin="0.0" width="235" display="CRISPR-Virus Coevolution">
+      <setup></setup>
+      <update></update>
+      <pen interval="1.0" mode="0" display="Viruses" color="-16777216" legend="true">
+        <setup></setup>
+        <update>plot 100 * (count viruses with [sequence = plot-virus]) / (max list 1 count viruses)</update>
+      </pen>
+      <pen interval="1.0" mode="0" display="Arrays" color="-2674135" legend="true">
+        <setup></setup>
+        <update><![CDATA[let total-arrays reduce sentence [array] of bacteria
+let virus-instances filter [ i -> i = plot-virus ] total-arrays
+plot 100 * length virus-instances / (max list 1 length total-arrays)]]></update>
+      </pen>
+    </plot>
+    <plot x="575" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="Frequency" y="320" xMin="0.0" height="195" legend="false" xMax="10.0" yMin="0.0" width="235" xAxis="Array Length" display="Array Histogram">
+      <setup></setup>
+      <update>update-histogram-ranges ([ length array ] of bacteria) 1</update>
+      <pen interval="1.0" mode="1" display="default" color="-16777216" legend="true">
+        <setup></setup>
+        <update>histogram [ length array ] of bacteria</update>
+      </pen>
+    </plot>
+    <monitor x="710" precision="2" y="255" height="60" fontSize="11" width="100" display="Std. Dev.">standard-deviation [length array] of bacteria</monitor>
+    <monitor x="575" precision="2" y="255" height="60" fontSize="11" width="130" display="Avg. Array Length">mean [length array] of bacteria</monitor>
+    <plot x="5" autoPlotX="true" yMax="10.0" autoPlotY="true" y="175" xMin="0.0" height="220" legend="true" xMax="10.0" yMin="0.0" width="280" display="Microbe Populations">
       <setup></setup>
       <update><![CDATA[; Don't scroll until the end of an autoscale window.
 if ticks > 715
@@ -353,7 +381,7 @@ if ticks > 715
         <update>plot count viruses</update>
       </pen>
     </plot>
-    <plot x="15" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="% Abundance" y="290" xMin="0.0" height="195" legend="false" xMax="10.0" yMin="0.0" xAxis="Ticks" display="Virus Relative Abundance" width="540" sizeVersion="0">
+    <plot x="5" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="% Abundance" y="400" xMin="0.0" height="195" legend="false" xMax="10.0" yMin="0.0" width="565" xAxis="Ticks" display="Virus Relative Abundance">
       <setup></setup>
       <update><![CDATA[; Don't scroll until the end of an autoscale window.
 if ticks > 715
@@ -363,18 +391,7 @@ if ticks > 715
   set-plot-x-range (ticks - 715) ticks
 ]]]></update>
     </plot>
-    <slider x="255" step="0.1" y="60" max="10" display="infection-chance" height="33" min="0" direction="Horizontal" default="5.0" variable="infection-chance" units="%" width="145" sizeVersion="0"></slider>
-    <slider x="255" step="1" y="15" max="100" display="max-virus-types" height="33" min="1" direction="Horizontal" default="50.0" variable="max-virus-types" width="145" sizeVersion="0"></slider>
-    <monitor x="590" precision="2" y="255" height="45" fontSize="11" display="Avg. Array Length" width="105" sizeVersion="0">mean [length array] of bacteria</monitor>
-    <plot x="565" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="Frequency" y="310" xMin="0.0" height="175" legend="false" xMax="10.0" yMin="0.0" xAxis="Array Length" display="Array Histogram" width="235" sizeVersion="0">
-      <setup></setup>
-      <update>update-histogram-ranges ([ length array ] of bacteria) 1</update>
-      <pen interval="1.0" mode="1" display="default" color="-16777216" legend="true">
-        <setup></setup>
-        <update>histogram [ length array ] of bacteria</update>
-      </pen>
-    </plot>
-    <plot x="275" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="Frequency" y="105" xMin="0.0" height="175" legend="true" xMax="10.0" yMin="0.0" xAxis="Sequence ID" display="Sequence Histogram" width="280" sizeVersion="0">
+    <plot x="290" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="Frequency" y="175" xMin="0.0" height="220" legend="true" xMax="10.0" yMin="0.0" width="280" xAxis="Sequence ID" display="Sequence Histogram">
       <setup></setup>
       <update>update-histogram-ranges sentence ([sequence] of viruses) (ifelse-value empty? [array] of bacteria [ [] ] [ reduce sentence [array] of bacteria ]) 1</update>
       <pen interval="1.0" mode="1" display="Viruses" color="-16777216" legend="true">
@@ -386,27 +403,10 @@ if ticks > 715
         <update>histogram (ifelse-value empty? [array] of bacteria [ [] ] [ reduce sentence [array] of bacteria ])</update>
       </pen>
     </plot>
-    <slider x="410" step="0.1" y="15" max="2" display="spacer-loss-chance" height="33" min="0" direction="Horizontal" default="1.0" variable="spacer-loss-chance" units="%" width="145" sizeVersion="0"></slider>
-    <monitor x="705" precision="2" y="255" height="45" fontSize="11" display="Std. Dev." width="75" sizeVersion="0">standard-deviation [length array] of bacteria</monitor>
-    <switch x="410" y="60" height="33" on="true" variable="crispr?" display="crispr?" width="145" sizeVersion="0"></switch>
-    <plot x="565" autoPlotX="true" yMax="10.0" autoPlotY="true" yAxis="% Abundance" y="15" xMin="0.0" height="185" legend="true" xMax="10.0" yMin="0.0" display="CRISPR-Virus Coevolution" width="235" sizeVersion="0">
-      <setup></setup>
-      <update></update>
-      <pen interval="1.0" mode="0" display="Viruses" color="-16777216" legend="true">
-        <setup></setup>
-        <update>plot 100 * (count viruses with [sequence = plot-virus]) / (max list 1 count viruses)</update>
-      </pen>
-      <pen interval="1.0" mode="0" display="Arrays" color="-2674135" legend="true">
-        <setup></setup>
-        <update><![CDATA[let total-arrays reduce sentence [array] of bacteria
-let virus-instances filter [ i -> i = plot-virus ] total-arrays
-plot 100 * length virus-instances / (max list 1 length total-arrays)]]></update>
-      </pen>
-    </plot>
-    <button x="565" y="210" height="33" disableUntilTicks="false" forever="false" kind="Observer" display="plot-new-virus" width="95" sizeVersion="0">set-current-plot "CRISPR-Virus Coevolution"
+    <button x="420" y="47" height="50" disableUntilTicks="false" forever="false" kind="Observer" width="150" display="plot-new-virus">set-current-plot "CRISPR-Virus Coevolution"
 clear-plot
 set plot-virus plotted-virus</button>
-    <slider x="670" step="1" y="210" max="max-virus-types - 1" display="plotted-virus" height="33" min="0" direction="Horizontal" default="35.0" variable="plotted-virus" width="130" sizeVersion="0"></slider>
+    <slider x="420" step="1" y="100" max="max-virus-types - 1" width="150" display="plotted-virus" height="50" min="0" direction="Horizontal" default="35.0" variable="plotted-virus"></slider>
   </widgets>
   <info><![CDATA[## WHAT IS IT?
 


### PR DESCRIPTION
Updates `Interface` tab of remaining `Sample Models/Biology/CRISPR` to new NetLogo 7 styling / sizing.

## Other notes
* Enables `Snap to Grid` on all models

## Before and After

<table>
  <tr>
    <td><img style="width:50%;" alt="bacterium_before" src="https://github.com/user-attachments/assets/d5876766-150e-4528-b7d6-f48bc9dd6d76"  >
</td>
    <td><img style="width:50%;" alt="bacterium_after" src="https://github.com/user-attachments/assets/dcb564a5-2dce-43c0-9429-2dc761c824b9"  ></td>
   </tr> 
    <tr>
    <td><img style="width:50%;" alt="bacterium_ls_before" src="https://github.com/user-attachments/assets/16c031d1-fea9-4af9-a1a9-8105a6adb286"  ></td>
    <td><img style="width:50%;" alt="bacterium_ls_after" src="https://github.com/user-attachments/assets/68308297-2d53-467a-b402-bb7145d66a34" >
</td>
   </tr> 
      <tr>
    <td><img style="width:50%;" alt="ecosystem_before" src="https://github.com/user-attachments/assets/bfc32953-2c93-4d08-b256-aec66aa2859c" >
</td>
    <td><img style="width:50%;" alt="ecosystem_after" src="https://github.com/user-attachments/assets/2c5d84ec-8afa-4a53-af73-673a3a522f69"  ></td>
   </tr> 
      <tr>
    <td><img style="width:50%;" alt="ecosystem_ls_before" src="https://github.com/user-attachments/assets/18534897-f393-418f-93b2-6fbb8ee21b8b" >
</td>
    <td><img style="width:50%;" alt="ecosystem_ls_after" src="https://github.com/user-attachments/assets/a1ff4d9c-47f2-4067-a94a-d95f35a501c1" ></td>
   </tr> 
</table>
